### PR TITLE
chore: align CI pipeline to Node.js 22 (LTS/Jod)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,11 @@
-name: Setup Node.js (v20) with Yarn v2 🚀
-description: Set up Node.js version 20 and enable Yarn v2 using Corepack
+name: Setup Node.js (v22) with Yarn v2 🚀
+description: Set up Node.js version 22 and enable Yarn v2 using Corepack
 
 inputs:
   node-version:
     description: The version of Node.js to set up.
     required: true
-    default: '20'
+    default: '22'
 
 outputs:
   node-version:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js Environment ⚙️
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Dependencies 🛠️
         run: yarn install --immutable
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js Environment ⚙️
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Dependencies 🛠️
         run: yarn install --immutable
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node.js Environment ⚙️
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install Dependencies 🛠️
         run: yarn install --immutable


### PR DESCRIPTION
Closes #8

## Summary

- Update `.github/actions/setup/action.yml` name, description, and default `node-version` from 20 to 22
- Update all three `node-version: 20` references in `.github/workflows/ci.yml` to `node-version: 22`
- Aligns the CI pipeline with the project's Node.js 22 (LTS/Jod) runtime, matching the `.node-version` file and `Dockerfile`

## Test plan

- [ ] Verify the CI pipeline runs successfully on the `chore/align-ci-node-22` branch
- [ ] Confirm `setup`, `tests`, and `deploy` jobs all use Node.js 22
- [ ] Ensure no regressions in lint, test, or build steps