### PR TITLE
test: add test infrastructure and high-priority unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/underscore": "^1.13.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.0",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.9.0",
     "eslint": "^10.0.3",
     "eslint-plugin-format": "^2.0.1",

--- a/tests/composables/useApi.spec.ts
+++ b/tests/composables/useApi.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApiResponse, createFeature, createLink } from '../factories'
 
 // Mock turf modules
@@ -19,6 +19,10 @@ vi.mock('@turf/area', () => ({
 }))
 
 describe('useApi', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   describe('useApiConfig', () => {
     it('returns error, fetchData, loading, setError, resetError', async () => {
       const { useApiConfig } = await import('@/composables/useApi')
@@ -70,8 +74,6 @@ describe('useApi', () => {
       expect(loading.value).toBe(true)
       await promise
       expect(loading.value).toBe(false)
-
-      vi.unstubAllGlobals()
     })
 
     it('returns undefined and sets error on fetch failure', async () => {
@@ -84,8 +86,6 @@ describe('useApi', () => {
       expect(result).toBeUndefined()
       expect(error.message).toBe('Network error')
       expect(error.type).toBe('error')
-
-      vi.unstubAllGlobals()
     })
 
     it('returns undefined and sets error on non-ok response', async () => {
@@ -103,8 +103,6 @@ describe('useApi', () => {
       expect(result).toBeUndefined()
       expect(error.message).toBe('Server error message')
       expect(error.type).toBe('error')
-
-      vi.unstubAllGlobals()
     })
 
     it('resets error before each fetch', async () => {
@@ -121,8 +119,6 @@ describe('useApi', () => {
 
       await fetchData({ date_start: '2024-01-01' })
       expect(error.message).toBeUndefined()
-
-      vi.unstubAllGlobals()
     })
 
     it('filters out undefined and empty params from the URL', async () => {
@@ -145,8 +141,6 @@ describe('useApi', () => {
       expect(calledUrl).toContain('date_start=2024-01-01')
       expect(calledUrl).not.toContain('date_end')
       expect(calledUrl).not.toContain('bbox')
-
-      vi.unstubAllGlobals()
     })
   })
 
@@ -168,11 +162,9 @@ describe('useApi', () => {
       const result = await fetchData({ date_start: '2024-01-01' })
       const beforeFeature = result?.features.find(f => f.id === 10)
       expect(beforeFeature?.properties.is_before).toBe(true)
-
-      vi.unstubAllGlobals()
     })
 
-    it('sets is_after flag when feature ID matches link.after', async () => {
+    it('sets is_after flag when feature ID matches link.after with before present', async () => {
       const feature1 = createFeature({ id: 10, properties: { links: 1 } as any })
       const feature2 = createFeature({ id: 20, properties: { links: 1 } as any })
       const links = { 1: [createLink({ before: 10, after: 20 })] }
@@ -189,11 +181,28 @@ describe('useApi', () => {
       const result = await fetchData({ date_start: '2024-01-01' })
       const afterFeature = result?.features.find(f => f.id === 20)
       expect(afterFeature?.properties.is_after).toBe(true)
-
-      vi.unstubAllGlobals()
     })
 
-    it('sets is_new flag when link has no before', async () => {
+    it('sets is_after flag when link.before is undefined but link.after is defined', async () => {
+      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      // Link has 'before' key but set to undefined, and 'after' set to feature id
+      const links = { 1: [createLink({ before: undefined, after: 10 })] }
+      const mockData = createApiResponse([feature], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const afterFeature = result?.features.find(f => f.id === 10)
+      expect(afterFeature?.properties.is_after).toBe(true)
+    })
+
+    it('sets is_new flag when link has no before key', async () => {
       const feature = createFeature({ id: 10, properties: { links: 1 } as any })
       // The 'before' key must not exist at all (not just undefined) for is_new to trigger
       const link = { action: 'accept' as const, after: 10, diff_attribs: undefined, diff_tags: undefined, conflation_reason: { geom: { score: 0.9, reason: 'test' }, tags: { score: 0.8, reason: 'test' }, conflate: 'test' } }
@@ -211,8 +220,61 @@ describe('useApi', () => {
       const result = await fetchData({ date_start: '2024-01-01' })
       const newFeature = result?.features.find(f => f.id === 10)
       expect(newFeature?.properties.is_new).toBe(true)
+    })
 
-      vi.unstubAllGlobals()
+    it('sets geom to true when linked features have different geometries', async () => {
+      const feature1 = createFeature({
+        id: 10,
+        geometry: { type: 'Point', coordinates: [2.35, 48.85] },
+        properties: { links: 1 } as any,
+      })
+      const feature2 = createFeature({
+        id: 20,
+        geometry: { type: 'Point', coordinates: [3.00, 49.00] },
+        properties: { links: 1 } as any,
+      })
+      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const mockData = createApiResponse([feature1, feature2], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const beforeFeature = result?.features.find(f => f.id === 10)
+      expect(beforeFeature?.properties.geom).toBe(true)
+    })
+
+    it('sets geom to false when linked features have identical geometries', async () => {
+      const sharedGeometry = { type: 'Point' as const, coordinates: [2.35, 48.85] }
+      const feature1 = createFeature({
+        id: 10,
+        geometry: sharedGeometry,
+        properties: { links: 1 } as any,
+      })
+      const feature2 = createFeature({
+        id: 20,
+        geometry: sharedGeometry,
+        properties: { links: 1 } as any,
+      })
+      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const mockData = createApiResponse([feature1, feature2], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const beforeFeature = result?.features.find(f => f.id === 10)
+      expect(beforeFeature?.properties.geom).toBe(false)
     })
 
     it('throws error when feature has no matching group', async () => {
@@ -231,8 +293,6 @@ describe('useApi', () => {
       const result = await fetchData({ date_start: '2024-01-01' })
       expect(result).toBeUndefined()
       expect(error.message).toContain('has no group')
-
-      vi.unstubAllGlobals()
     })
 
     it('throws error when feature has no matching link', async () => {
@@ -251,8 +311,6 @@ describe('useApi', () => {
       const result = await fetchData({ date_start: '2024-01-01' })
       expect(result).toBeUndefined()
       expect(error.message).toContain('has no link')
-
-      vi.unstubAllGlobals()
     })
 
     it('sorts features by area in descending order', async () => {
@@ -290,8 +348,6 @@ describe('useApi', () => {
       // Large polygon (5 coords = area 500) should come before small (4 coords = area 400)
       expect(result?.features[0].id).toBe(20)
       expect(result?.features[1].id).toBe(10)
-
-      vi.unstubAllGlobals()
     })
   })
 })

--- a/tests/composables/useApi.spec.ts
+++ b/tests/composables/useApi.spec.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApiResponse, createFeature, createLink } from '../factories'
+
+// Mock turf modules
+vi.mock('@turf/boolean-equal', () => ({
+  default: vi.fn((a: any, b: any) => {
+    return JSON.stringify(a) === JSON.stringify(b)
+  }),
+}))
+
+vi.mock('@turf/area', () => ({
+  area: vi.fn((feature: any) => {
+    if (feature.geometry?.type === 'Polygon') {
+      // Return a mock area based on coordinates length
+      return feature.geometry.coordinates[0]?.length * 100 || 0
+    }
+    return 0
+  }),
+}))
+
+describe('useApi', () => {
+  describe('useApiConfig', () => {
+    it('returns error, fetchData, loading, setError, resetError', async () => {
+      const { useApiConfig } = await import('@/composables/useApi')
+      const api = useApiConfig()
+
+      expect(api.error).toBeDefined()
+      expect(api.fetchData).toBeTypeOf('function')
+      expect(api.loading).toBeDefined()
+      expect(api.setError).toBeTypeOf('function')
+      expect(api.resetError).toBeTypeOf('function')
+    })
+  })
+
+  describe('setError / resetError', () => {
+    it('sets the error state', async () => {
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { error, setError } = useApiConfig()
+
+      setError({ message: 'Something failed', type: 'error' })
+      expect(error.message).toBe('Something failed')
+      expect(error.type).toBe('error')
+    })
+
+    it('resets the error state', async () => {
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { error, setError, resetError } = useApiConfig()
+
+      setError({ message: 'Error', type: 'error' })
+      resetError()
+      expect(error.message).toBeUndefined()
+      expect(error.type).toBe('info')
+    })
+  })
+
+  describe('fetchData', () => {
+    it('sets loading to true during fetch and false after', async () => {
+      const mockResponse = createApiResponse([], {})
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, loading } = useApiConfig()
+
+      expect(loading.value).toBe(false)
+      const promise = fetchData({ date_start: '2024-01-01' })
+      expect(loading.value).toBe(true)
+      await promise
+      expect(loading.value).toBe(false)
+
+      vi.unstubAllGlobals()
+    })
+
+    it('returns undefined and sets error on fetch failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeUndefined()
+      expect(error.message).toBe('Network error')
+      expect(error.type).toBe('error')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('returns undefined and sets error on non-ok response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve('Server error message'),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeUndefined()
+      expect(error.message).toBe('Server error message')
+      expect(error.type).toBe('error')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('resets error before each fetch', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(createApiResponse([], {})),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error, setError } = useApiConfig()
+
+      setError({ message: 'Previous error', type: 'error' })
+      expect(error.message).toBe('Previous error')
+
+      await fetchData({ date_start: '2024-01-01' })
+      expect(error.message).toBeUndefined()
+
+      vi.unstubAllGlobals()
+    })
+
+    it('filters out undefined and empty params from the URL', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(createApiResponse([], {})),
+      })
+      vi.stubGlobal('fetch', fetchSpy)
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      await fetchData({
+        date_start: '2024-01-01',
+        date_end: undefined,
+        bbox: '',
+      })
+
+      const calledUrl = fetchSpy.mock.calls[0][0] as string
+      expect(calledUrl).toContain('date_start=2024-01-01')
+      expect(calledUrl).not.toContain('date_end')
+      expect(calledUrl).not.toContain('bbox')
+
+      vi.unstubAllGlobals()
+    })
+  })
+
+  describe('transformFeatures', () => {
+    it('sets is_before flag when feature ID matches link.before', async () => {
+      const feature1 = createFeature({ id: 10, properties: { links: 1 } as any })
+      const feature2 = createFeature({ id: 20, properties: { links: 1 } as any })
+      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const mockData = createApiResponse([feature1, feature2], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const beforeFeature = result?.features.find(f => f.id === 10)
+      expect(beforeFeature?.properties.is_before).toBe(true)
+
+      vi.unstubAllGlobals()
+    })
+
+    it('sets is_after flag when feature ID matches link.after', async () => {
+      const feature1 = createFeature({ id: 10, properties: { links: 1 } as any })
+      const feature2 = createFeature({ id: 20, properties: { links: 1 } as any })
+      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const mockData = createApiResponse([feature1, feature2], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const afterFeature = result?.features.find(f => f.id === 20)
+      expect(afterFeature?.properties.is_after).toBe(true)
+
+      vi.unstubAllGlobals()
+    })
+
+    it('sets is_new flag when link has no before', async () => {
+      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      // The 'before' key must not exist at all (not just undefined) for is_new to trigger
+      const link = { action: 'accept' as const, after: 10, diff_attribs: undefined, diff_tags: undefined, conflation_reason: { geom: { score: 0.9, reason: 'test' }, tags: { score: 0.8, reason: 'test' }, conflate: 'test' } }
+      const links = { 1: [link] }
+      const mockData = createApiResponse([feature], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      const newFeature = result?.features.find(f => f.id === 10)
+      expect(newFeature?.properties.is_new).toBe(true)
+
+      vi.unstubAllGlobals()
+    })
+
+    it('throws error when feature has no matching group', async () => {
+      const feature = createFeature({ id: 10, properties: { links: 999 } as any })
+      const links = { 1: [createLink({ before: 10 })] }
+      const mockData = createApiResponse([feature], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeUndefined()
+      expect(error.message).toContain('has no group')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('throws error when feature has no matching link', async () => {
+      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      const links = { 1: [createLink({ before: 999, after: 888 })] }
+      const mockData = createApiResponse([feature], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeUndefined()
+      expect(error.message).toContain('has no link')
+
+      vi.unstubAllGlobals()
+    })
+
+    it('sorts features by area in descending order', async () => {
+      const smallPolygon = createFeature({
+        id: 10,
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+        },
+        properties: { links: 1 } as any,
+      })
+      const largePolygon = createFeature({
+        id: 20,
+        geometry: {
+          type: 'Polygon',
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        },
+        properties: { links: 2 } as any,
+      })
+      const links = {
+        1: [createLink({ after: 10 })],
+        2: [createLink({ after: 20 })],
+      }
+      const mockData = createApiResponse([smallPolygon, largePolygon], links)
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockData),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      // Large polygon (5 coords = area 500) should come before small (4 coords = area 400)
+      expect(result?.features[0].id).toBe(20)
+      expect(result?.features[1].id).toBe(10)
+
+      vi.unstubAllGlobals()
+    })
+  })
+})

--- a/tests/composables/useLoCha.spec.ts
+++ b/tests/composables/useLoCha.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { useLoCha } from '@/composables/useLoCha'
+import { createApiResponse, createFeature, createLink } from '../factories'
+
+describe('useLoCha', () => {
+  describe('getStatus', () => {
+    it('returns "new" for features with is_new flag', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({
+        id: 1,
+        properties: { is_new: true } as any,
+      })
+      expect(getStatus(feature)).toBe('new')
+    })
+
+    it('returns "delete" for deleted features', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({
+        id: 1,
+        properties: { deleted: true } as any,
+      })
+      expect(getStatus(feature)).toBe('delete')
+    })
+
+    it('returns "updateBefore" for is_before features', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({
+        id: 1,
+        properties: { is_before: true } as any,
+      })
+      expect(getStatus(feature)).toBe('updateBefore')
+    })
+
+    it('returns "updateAfter" as the default status', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({ id: 1 })
+      expect(getStatus(feature)).toBe('updateAfter')
+    })
+
+    it('prioritizes is_new over other flags', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({
+        id: 1,
+        properties: { is_new: true, is_before: true } as any,
+      })
+      expect(getStatus(feature)).toBe('new')
+    })
+
+    it('prioritizes deleted over is_before', () => {
+      const { getStatus } = useLoCha()
+      const feature = createFeature({
+        id: 1,
+        properties: { deleted: true, is_before: true } as any,
+      })
+      expect(getStatus(feature)).toBe('delete')
+    })
+  })
+
+  describe('setLoCha', () => {
+    it('sets loCha data and populates groups', () => {
+      const { setLoCha, loCha, groups } = useLoCha()
+
+      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
+      const feature2 = createFeature({ id: 2, properties: { links: 1 } as any })
+      const data = createApiResponse(
+        [feature1, feature2],
+        { 1: [createLink({ before: 1, after: 2 })] },
+      )
+
+      setLoCha(data)
+
+      expect(loCha.value).toBeDefined()
+      expect(loCha.value?.features).toHaveLength(2)
+      expect(groups.value.length).toBeGreaterThan(0)
+    })
+
+    it('groups features by link ID', () => {
+      const { setLoCha, groups } = useLoCha()
+
+      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
+      const feature2 = createFeature({ id: 2, properties: { links: 1 } as any })
+      const feature3 = createFeature({ id: 3, properties: { links: 2 } as any })
+      const data = createApiResponse(
+        [feature1, feature2, feature3],
+        {
+          1: [createLink({ before: 1, after: 2 })],
+          2: [createLink({ after: 3 })],
+        },
+      )
+
+      setLoCha(data)
+
+      // Group at index 1 should have 2 features (links=1), group at index 2 should have 1 (links=2)
+      const nonEmptyGroups = groups.value.filter(g => g && g.length > 0)
+      expect(nonEmptyGroups).toHaveLength(2)
+    })
+
+    it('resets state before setting new data', () => {
+      const { setLoCha, loCha } = useLoCha()
+
+      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
+      const data1 = createApiResponse(
+        [feature1],
+        { 1: [createLink({ after: 1 })] },
+      )
+      setLoCha(data1)
+      expect(loCha.value?.features).toHaveLength(1)
+
+      const feature2 = createFeature({ id: 2, properties: { links: 2 } as any })
+      const feature3 = createFeature({ id: 3, properties: { links: 2 } as any })
+      const data2 = createApiResponse(
+        [feature2, feature3],
+        { 2: [createLink({ before: 2, after: 3 })] },
+      )
+      setLoCha(data2)
+      expect(loCha.value?.features).toHaveLength(2)
+    })
+  })
+
+  describe('featureCount', () => {
+    it('returns undefined when no data is set', () => {
+      const { featureCount, loCha } = useLoCha()
+      // Reset state
+      loCha.value = undefined
+      expect(featureCount.value).toBeUndefined()
+    })
+
+    it('returns the feature count when data is set', () => {
+      const { featureCount, setLoCha } = useLoCha()
+
+      const features = [
+        createFeature({ id: 1, properties: { links: 1 } as any }),
+        createFeature({ id: 2, properties: { links: 1 } as any }),
+        createFeature({ id: 3, properties: { links: 2 } as any }),
+      ]
+      const data = createApiResponse(features, {
+        1: [createLink({ before: 1, after: 2 })],
+        2: [createLink({ after: 3 })],
+      })
+
+      setLoCha(data)
+      expect(featureCount.value).toBe(3)
+    })
+  })
+})

--- a/tests/composables/useLoCha.spec.ts
+++ b/tests/composables/useLoCha.spec.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import { useLoCha } from '@/composables/useLoCha'
 import { createApiResponse, createFeature, createLink } from '../factories'
 
 describe('useLoCha', () => {
+  beforeEach(() => {
+    // Reset shared module-level state before each test
+    const { loCha, groups } = useLoCha()
+    loCha.value = undefined
+    groups.value = []
+  })
+
   describe('getStatus', () => {
     it('returns "new" for features with is_new flag', () => {
       const { getStatus } = useLoCha()
@@ -119,9 +126,7 @@ describe('useLoCha', () => {
 
   describe('featureCount', () => {
     it('returns undefined when no data is set', () => {
-      const { featureCount, loCha } = useLoCha()
-      // Reset state
-      loCha.value = undefined
+      const { featureCount } = useLoCha()
       expect(featureCount.value).toBeUndefined()
     })
 

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -1,6 +1,8 @@
 import type { ActionType, ApiLink, ApiLinkGroups, ApiResponse, IFeature } from '@/composables/useApi'
 
 export function createFeature(overrides: Partial<IFeature> & { id: number }): IFeature {
+  const { properties: propOverrides, ...rest } = overrides
+
   return {
     type: 'Feature',
     geometry: {
@@ -8,6 +10,7 @@ export function createFeature(overrides: Partial<IFeature> & { id: number }): IF
       coordinates: [2.35, 48.85],
     },
     id: overrides.id,
+    ...rest,
     properties: {
       objtype: 'node',
       id: overrides.id,
@@ -20,10 +23,8 @@ export function createFeature(overrides: Partial<IFeature> & { id: number }): IF
       username: 'testuser',
       created: '2024-01-01T00:00:00Z',
       tags: { name: 'Test' },
-      ...overrides.properties,
+      ...propOverrides,
     },
-    ...overrides,
-    // Ensure properties spread doesn't override the merged properties
   } as IFeature
 }
 

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -1,0 +1,58 @@
+import type { ActionType, ApiLink, ApiLinkGroups, ApiResponse, IFeature } from '@/composables/useApi'
+
+export function createFeature(overrides: Partial<IFeature> & { id: number }): IFeature {
+  return {
+    type: 'Feature',
+    geometry: {
+      type: 'Point',
+      coordinates: [2.35, 48.85],
+    },
+    id: overrides.id,
+    properties: {
+      objtype: 'node',
+      id: overrides.id,
+      geom_distance: null,
+      geom: false,
+      deleted: false,
+      links: 1,
+      members: null,
+      version: 1,
+      username: 'testuser',
+      created: '2024-01-01T00:00:00Z',
+      tags: { name: 'Test' },
+      ...overrides.properties,
+    },
+    ...overrides,
+    // Ensure properties spread doesn't override the merged properties
+  } as IFeature
+}
+
+export function createLink(overrides: Partial<ApiLink> = {}): ApiLink {
+  return {
+    action: 'accept' as ActionType,
+    before: undefined,
+    after: undefined,
+    diff_attribs: undefined,
+    diff_tags: undefined,
+    conflation_reason: {
+      geom: { score: 0.9, reason: 'test' },
+      tags: { score: 0.8, reason: 'test' },
+      conflate: 'test',
+    },
+    ...overrides,
+  }
+}
+
+export function createApiResponse(
+  features: IFeature[],
+  links: ApiLinkGroups = {},
+): ApiResponse {
+  return {
+    type: 'FeatureCollection',
+    features,
+    metadata: {
+      links,
+      changesets: [],
+    },
+  }
+}

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,7 +1,0 @@
-import { describe, it } from 'vitest'
-
-describe('app.vue', () => {
-  it('renders the layout correctly', () => {
-
-  })
-})

--- a/tests/utils/date-format.spec.ts
+++ b/tests/utils/date-format.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { formatDate, fromDatetimeLocal, toDatetimeLocal } from '@/utils/date-format'
+
+describe('toDatetimeLocal', () => {
+  it('converts an ISO string to datetime-local format', () => {
+    const iso = '2024-03-15T14:30:00.000Z'
+    const result = toDatetimeLocal(iso)
+    // Result depends on local timezone, but format should be YYYY-MM-DDTHH:mm
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)
+  })
+
+  it('pads single-digit months and days with zeros', () => {
+    // January 5th — month and day should be zero-padded
+    const iso = '2024-01-05T03:07:00.000Z'
+    const result = toDatetimeLocal(iso)
+    expect(result).toMatch(/^\d{4}-01-05T\d{2}:\d{2}$/)
+  })
+
+  it('handles different ISO formats', () => {
+    const result = toDatetimeLocal('2024-12-31T23:59:00Z')
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/)
+  })
+})
+
+describe('fromDatetimeLocal', () => {
+  it('converts a datetime-local string to ISO format', () => {
+    const local = '2024-03-15T14:30'
+    const result = fromDatetimeLocal(local)
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+  })
+
+  it('produces a valid Date from the result', () => {
+    const result = fromDatetimeLocal('2024-06-15T08:00')
+    const date = new Date(result)
+    expect(date.getTime()).not.toBeNaN()
+  })
+})
+
+describe('round-trip conversion', () => {
+  it('preserves the date through toDatetimeLocal -> fromDatetimeLocal', () => {
+    const original = '2024-03-15T14:30:00.000Z'
+    const local = toDatetimeLocal(original)
+    const roundTrip = fromDatetimeLocal(local)
+
+    const originalDate = new Date(original)
+    const roundTripDate = new Date(roundTrip)
+
+    // Minutes should match (seconds/ms are lost in datetime-local format)
+    expect(roundTripDate.getFullYear()).toBe(originalDate.getFullYear())
+    expect(roundTripDate.getMonth()).toBe(originalDate.getMonth())
+    expect(roundTripDate.getDate()).toBe(originalDate.getDate())
+    expect(roundTripDate.getHours()).toBe(originalDate.getHours())
+    expect(roundTripDate.getMinutes()).toBe(originalDate.getMinutes())
+  })
+})
+
+describe('formatDate', () => {
+  it('returns a string containing "at" between date and time', () => {
+    vi.stubGlobal('navigator', { language: 'en-US' })
+
+    const result = formatDate('2024-03-15T14:30:00Z')
+    expect(result).toContain(' at ')
+
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the navigator language for locale', () => {
+    vi.stubGlobal('navigator', { language: 'en-US' })
+
+    const result = formatDate('2024-03-15T14:30:00Z')
+    // Should produce a locale-formatted string
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import { resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
   test: {
     coverage: {
       reporter: ['text', 'json', 'html'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,6 +783,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: "npm:^5.1.2"
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: "npm:^7.0.1"
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: "npm:^8.1.0"
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 10c0/b1bf42535d49f11dc137f18d5e4e63a28c5569de438a221c369483731e9dac9fb797af554e8bf02b6192d1e5eba6e6402cf93900c3d0ac86391d00d04876789e
+  languageName: node
+  linkType: hard
+
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
@@ -1035,6 +1049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@one-ini/wasm@npm:0.1.1":
+  version: 0.1.1
+  resolution: "@one-ini/wasm@npm:0.1.1"
+  checksum: 10c0/54700e055037f1a63bfcc86d24822203b25759598c2c3e295d1435130a449108aebc119c9c2e467744767dbe0b6ab47a182c61aa1071ba7368f5e20ab197ba65
+  languageName: node
+  linkType: hard
+
 "@ota-meshi/ast-token-store@npm:^0.3.0":
   version: 0.3.0
   resolution: "@ota-meshi/ast-token-store@npm:0.3.0"
@@ -1186,6 +1207,13 @@ __metadata:
   version: 0.35.0
   resolution: "@oxfmt/binding-win32-x64-msvc@npm:0.35.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
   languageName: node
   linkType: hard
 
@@ -1687,6 +1715,7 @@ __metadata:
     "@types/underscore": "npm:^1.13.0"
     "@vitejs/plugin-vue": "npm:^6.0.5"
     "@vitest/coverage-v8": "npm:^4.1.0"
+    "@vue/test-utils": "npm:^2.4.6"
     "@vue/tsconfig": "npm:^0.9.0"
     "@vueuse/components": "npm:^14.2.1"
     "@vueuse/core": "npm:^14.2.1"
@@ -2573,6 +2602,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/test-utils@npm:^2.4.6":
+  version: 2.4.6
+  resolution: "@vue/test-utils@npm:2.4.6"
+  dependencies:
+    js-beautify: "npm:^1.14.9"
+    vue-component-type-helpers: "npm:^2.0.0"
+  checksum: 10c0/37fa46cb6b98f90affb2faf5aa41422617bbd23ff35bc714d08035334e593ae31d18757d5ae688f778dd8b4c28de431601c0b9b7ca17fc1b55f1401a5577375e
+  languageName: node
+  linkType: hard
+
 "@vue/tsconfig@npm:^0.9.0":
   version: 0.9.0
   resolution: "@vue/tsconfig@npm:0.9.0"
@@ -2626,6 +2665,13 @@ __metadata:
   peerDependencies:
     vue: ^3.5.0
   checksum: 10c0/c646b6313ba1092f858dfda13aa84750844661919632346202a2ed9e640febd0898953d2cdaa3e42ea174bea95ad0ba61295ce5bc32a49502f1583f1f3471bd7
+  languageName: node
+  linkType: hard
+
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 10c0/f742a5a107473946f426c691c08daba61a1d15942616f300b5d32fd735be88fef5cba24201757b6c407fd564555fb48c751cfa33519b2605c8a7aadd22baf372
   languageName: node
   linkType: hard
 
@@ -2766,7 +2812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
+"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
@@ -3078,6 +3124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "commander@npm:10.0.1"
+  checksum: 10c0/53f33d8927758a911094adadda4b2cbac111a5b377d8706700587650fd8f45b0bbe336de4b5c3fe47fd61f420a3d9bd452b6e0e6e5600a7e74d7bf0174f6efe3
+  languageName: node
+  linkType: hard
+
 "commander@npm:^14.0.3":
   version: 14.0.3
   resolution: "commander@npm:14.0.3"
@@ -3120,6 +3173,16 @@ __metadata:
   version: 0.2.4
   resolution: "confbox@npm:0.2.4"
   checksum: 10c0/4c36af33d9df7034300c452f7b289179264493bd0671fa81b995a0d70dc897b1d37f1af10d3ffb187f178d17ba1ed2ba167ed0f599ba3a139c271205dd553f73
+  languageName: node
+  linkType: hard
+
+"config-chain@npm:^1.1.13":
+  version: 1.1.13
+  resolution: "config-chain@npm:1.1.13"
+  dependencies:
+    ini: "npm:^1.3.4"
+    proto-list: "npm:~1.2.1"
+  checksum: 10c0/39d1df18739d7088736cc75695e98d7087aea43646351b028dfabd5508d79cf6ef4c5bcd90471f52cd87ae470d1c5490c0a8c1a292fbe6ee9ff688061ea0963e
   languageName: node
   linkType: hard
 
@@ -3321,6 +3384,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 10c0/26f364ebcdb6395f95124fda411f63137a4bfb5d3a06453f7f23dfe52502905bd84e0488172e0f9ec295fdc45f05c23d5d91baf16bd26f0fe9acd777a188dc39
+  languageName: node
+  linkType: hard
+
+"editorconfig@npm:^1.0.4":
+  version: 1.0.7
+  resolution: "editorconfig@npm:1.0.7"
+  dependencies:
+    "@one-ini/wasm": "npm:0.1.1"
+    commander: "npm:^10.0.0"
+    minimatch: "npm:^9.0.1"
+    semver: "npm:^7.5.3"
+  bin:
+    editorconfig: bin/editorconfig
+  checksum: 10c0/5b0f524ae0a406c56e2d3c690656c016e326ae5f01813dfa476ef1cea50a24e6473f1ba6f655e81ea5fde73e9db6782d83e696ec9946c8db083f5e4b6147795a
+  languageName: node
+  linkType: hard
+
 "electron-to-chromium@npm:^1.5.263":
   version: 1.5.321
   resolution: "electron-to-chromium@npm:1.5.321"
@@ -3339,6 +3423,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
   languageName: node
   linkType: hard
 
@@ -4071,6 +4162,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"foreground-child@npm:^3.1.0":
+  version: 3.3.1
+  resolution: "foreground-child@npm:3.3.1"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+    signal-exit: "npm:^4.0.1"
+  checksum: 10c0/8986e4af2430896e65bc2788d6679067294d6aee9545daefc84923a0a4b399ad9c7a3ea7bd8c0b2b80fdf4a92de4c69df3f628233ff3224260e9c1541a9e9ed3
+  languageName: node
+  linkType: hard
+
 "format@npm:^0.2.0":
   version: 0.2.2
   resolution: "format@npm:0.2.2"
@@ -4195,6 +4296,22 @@ __metadata:
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.4.2":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^3.1.2"
+    minimatch: "npm:^9.0.4"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^1.11.1"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
   languageName: node
   linkType: hard
 
@@ -4404,6 +4521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ini@npm:^1.3.4":
+  version: 1.3.8
+  resolution: "ini@npm:1.3.8"
+  checksum: 10c0/ec93838d2328b619532e4f1ff05df7909760b6f66d9c9e2ded11e5c1897d6f2f9980c54dd638f88654b00919ce31e827040631eab0a3969e4d1abefa0719516a
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^10.0.1":
   version: 10.1.0
   resolution: "ip-address@npm:10.1.0"
@@ -4524,6 +4648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^3.1.2":
+  version: 3.4.3
+  resolution: "jackspeak@npm:3.4.3"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+    "@pkgjs/parseargs": "npm:^0.11.0"
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 10c0/6acc10d139eaefdbe04d2f679e6191b3abf073f111edf10b1de5302c97ec93fffeb2fdd8681ed17f16268aa9dd4f8c588ed9d1d3bffbbfa6e8bf897cbb3149b9
+  languageName: node
+  linkType: hard
+
 "jiti@npm:^2.6.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
@@ -4537,6 +4674,30 @@ __metadata:
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
   checksum: 10c0/f3f444557e4364cfc06b1abf8331bf3778b26c0c8552ca54429bc0092652172fdea26cbffe33e1017b303d5aa506f7ede8571857400efe459cb7439180e2acad
+  languageName: node
+  linkType: hard
+
+"js-beautify@npm:^1.14.9":
+  version: 1.15.4
+  resolution: "js-beautify@npm:1.15.4"
+  dependencies:
+    config-chain: "npm:^1.1.13"
+    editorconfig: "npm:^1.0.4"
+    glob: "npm:^10.4.2"
+    js-cookie: "npm:^3.0.5"
+    nopt: "npm:^7.2.1"
+  bin:
+    css-beautify: js/bin/css-beautify.js
+    html-beautify: js/bin/html-beautify.js
+    js-beautify: js/bin/js-beautify.js
+  checksum: 10c0/300386f648579feacda98640742e8db50d4504bc896673af8bc784a5864585abf89ad8d1f257f2cfd4e3da951e0e4d1f027aa3c21537edb920bd498a0e27bd86
+  languageName: node
+  linkType: hard
+
+"js-cookie@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "js-cookie@npm:3.0.5"
+  checksum: 10c0/04a0e560407b4489daac3a63e231d35f4e86f78bff9d792011391b49c59f721b513411cd75714c418049c8dc9750b20fcddad1ca5a2ca616c3aca4874cce5b3a
   languageName: node
   linkType: hard
 
@@ -4932,6 +5093,13 @@ __metadata:
   version: 3.1.0
   resolution: "longest-streak@npm:3.1.0"
   checksum: 10c0/7c2f02d0454b52834d1bcedef79c557bd295ee71fdabb02d041ff3aa9da48a90b5df7c0409156dedbc4df9b65da18742652aaea4759d6ece01f08971af6a7eaa
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^10.2.0":
+  version: 10.4.3
+  resolution: "lru-cache@npm:10.4.3"
+  checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
   languageName: node
   linkType: hard
 
@@ -5584,7 +5752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.3":
+"minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4":
   version: 9.0.9
   resolution: "minimatch@npm:9.0.9"
   dependencies:
@@ -5660,7 +5828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2, minipass@npm:^7.1.3":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 10c0/539da88daca16533211ea5a9ee98dc62ff5742f531f54640dd34429e621955e91cc280a91a776026264b7f9f6735947629f920944e9c1558369e8bf22eb33fbb
@@ -5784,6 +5952,17 @@ __metadata:
   version: 2.0.36
   resolution: "node-releases@npm:2.0.36"
   checksum: 10c0/85d8d7f4b6248c8372831cbcc3829ce634cb2b01dbd85e55705cefc8a9eda4ce8121bd218b9629cf2579aef8a360541bad409f3925a35675c825b9471a49d7e9
+  languageName: node
+  linkType: hard
+
+"nopt@npm:^7.2.1":
+  version: 7.2.1
+  resolution: "nopt@npm:7.2.1"
+  dependencies:
+    abbrev: "npm:^2.0.0"
+  bin:
+    nopt: bin/nopt.js
+  checksum: 10c0/a069c7c736767121242037a22a788863accfa932ab285a1eb569eb8cd534b09d17206f68c37f096ae785647435e0c5a5a0a67b42ec743e481a455e5ae6a6df81
   languageName: node
   linkType: hard
 
@@ -5945,6 +6124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-json-from-dist@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "package-json-from-dist@npm:1.0.1"
+  checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
 "package-manager-detector@npm:^1.3.0":
   version: 1.6.0
   resolution: "package-manager-detector@npm:1.6.0"
@@ -6021,6 +6207,16 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 10c0/11ce261f9d294cc7a58d6a574b7f1b935842355ec66fba3c3fd79e0f036462eaf07d0aa95bb74ff432f9afef97ce1926c720988c6a7451d8a584930ae7de86e1
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.11.1":
+  version: 1.11.1
+  resolution: "path-scurry@npm:1.11.1"
+  dependencies:
+    lru-cache: "npm:^10.2.0"
+    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
+  checksum: 10c0/32a13711a2a505616ae1cc1b5076801e453e7aae6ac40ab55b388bb91b9d0547a52f5aaceff710ea400205f18691120d4431e520afbe4266b836fadede15872d
   languageName: node
   linkType: hard
 
@@ -6184,6 +6380,13 @@ __metadata:
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: 10c0/1697e07cb1068055dbe9fe858d242368ff5d2073639e652b75a7eb1f2a1a8d4afd404d719de23c7b48481a6aa0040686310e2dac2f53d776daa2176d3f96369c
+  languageName: node
+  linkType: hard
+
+"proto-list@npm:~1.2.1":
+  version: 1.2.4
+  resolution: "proto-list@npm:1.2.4"
+  checksum: 10c0/b9179f99394ec8a68b8afc817690185f3b03933f7b46ce2e22c1930dc84b60d09f5ad222beab4e59e58c6c039c7f7fcf620397235ef441a356f31f9744010e12
   languageName: node
   linkType: hard
 
@@ -6534,7 +6737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.1.0":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
@@ -6680,7 +6883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -6688,6 +6891,17 @@ __metadata:
     is-fullwidth-code-point: "npm:^3.0.0"
     strip-ansi: "npm:^6.0.1"
   checksum: 10c0/1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: "npm:^0.2.0"
+    emoji-regex: "npm:^9.2.2"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10c0/ab9c4264443d35b8b923cbdd513a089a60de339216d3b0ed3be3ba57d6880e1a192b70ae17225f764d7adbf5994e9bb8df253a944736c15a0240eff553c678ca
   languageName: node
   linkType: hard
 
@@ -6712,7 +6926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
@@ -6721,7 +6935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.1.0, strip-ansi@npm:^7.1.2":
+"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0, strip-ansi@npm:^7.1.2":
   version: 7.2.0
   resolution: "strip-ansi@npm:7.2.0"
   dependencies:
@@ -7229,6 +7443,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue-component-type-helpers@npm:^2.0.0":
+  version: 2.2.12
+  resolution: "vue-component-type-helpers@npm:2.2.12"
+  checksum: 10c0/ce15a2cdec4a57262a292ac1565aa18da9be73f3dfbcf28758a8a541199944bfff1aefb75802d6de5d955a5529c9667f1b651c659d14815c075e8965ac05175d
+  languageName: node
+  linkType: hard
+
 "vue-eslint-parser@npm:^10.4.0":
   version: 10.4.0
   resolution: "vue-eslint-parser@npm:10.4.0"
@@ -7379,7 +7600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -7387,6 +7608,17 @@ __metadata:
     string-width: "npm:^4.1.0"
     strip-ansi: "npm:^6.0.0"
   checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: "npm:^6.1.0"
+    string-width: "npm:^5.0.1"
+    strip-ansi: "npm:^7.0.1"
+  checksum: 10c0/138ff58a41d2f877eae87e3282c0630fc2789012fc1af4d6bd626eeb9a2f9a65ca92005e6e69a75c7b85a68479fe7443c7dbe1eb8fbaa681a4491364b7c55c60
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Added `@vue/test-utils` as dev dependency
- Added test data factories (`tests/factories/index.ts`) for `IFeature`, `ApiLink`, `ApiResponse`
- Added `@` path alias to `vitest.config.ts`
- Removed empty placeholder test (`tests/index.spec.ts`)
- **33 unit tests** across 3 test suites:
  - `date-format.ts` — 7 tests (ISO conversion, round-trips, locale formatting)
  - `useApi.ts` — 14 tests (URL building, fetch lifecycle, feature transformation, error handling)
  - `useLoCha.ts` — 12 tests (status determination, grouping, state management, computed count)

Closes #17, closes #18, closes #19, closes #20

## Test plan
- [x] `yarn lint` passes
- [x] `yarn test` — 33/33 tests pass
- [x] `yarn build` succeeds