### PR TITLE
Add usage documentation and fix package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,109 @@
 
 A Vue-based UI component for visualizing and interacting with OpenStreetMap logical history data.
 
-## Getting started
+## Usage
+
+### Installation
+
+```bash
+npm install @teritorio/openstreetmap-logical-history-component
+# or
+yarn add @teritorio/openstreetmap-logical-history-component
+```
+
+#### Peer dependencies
+
+The component requires `vue` and `maplibre-gl` as peer dependencies:
+
+```bash
+npm install vue maplibre-gl
+```
+
+### Importing
+
+```ts
+import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
+import '@teritorio/openstreetmap-logical-history-component/style.css'
+```
+
+### Basic example
+
+```vue
+<script setup lang="ts">
+import type { ApiResponse } from '@teritorio/openstreetmap-logical-history-component'
+import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
+import { ref } from 'vue'
+import '@teritorio/openstreetmap-logical-history-component/style.css'
+
+const data = ref<ApiResponse>()
+
+// Fetch data from your API and assign it to `data`
+</script>
+
+<template>
+  <LoCha :data="data" />
+</template>
+```
+
+### Props
+
+| Prop              | Type          | Default     | Description                                                   |
+| ----------------- | ------------- | ----------- | ------------------------------------------------------------- |
+| `data`            | `ApiResponse` | `undefined` | The API response containing features and metadata to display. |
+| `reasonCollapsed` | `boolean`     | `true`      | Whether conflation reason details are collapsed by default.   |
+
+### Slots
+
+#### `#tags-diff`
+
+A scoped slot exposed on each feature group, allowing custom rendering of tag diffs.
+
+Slot props:
+
+| Prop     | Type                     | Description                                             |
+| -------- | ------------------------ | ------------------------------------------------------- |
+| `date`   | `string`                 | The feature's creation date.                            |
+| `title`  | `string`                 | A label for the tag diff (present on "after" features). |
+| `diff`   | `Actions`                | The tag diff actions.                                   |
+| `src`    | `IFeature['properties']` | Source (before) feature properties.                     |
+| `dst`    | `IFeature['properties']` | Destination (after) feature properties.                 |
+| `reason` | `Reason`                 | The conflation reason for this link.                    |
+
+### Types
+
+All consumer-facing types are exported from the package entry point:
+
+```ts
+import type {
+  Action,
+  Actions,
+  ActionType,
+  ApiLink,
+  ApiLinkGroups,
+  ApiResponse,
+  IFeature,
+  Reason,
+  ReasonGeom,
+  ReasonTags,
+} from '@teritorio/openstreetmap-logical-history-component'
+```
+
+### `ApiResponse` shape
+
+`ApiResponse` extends `GeoJSON.FeatureCollection` with:
+
+- `features` — an array of `IFeature` objects (GeoJSON features with OSM-specific properties such as `objtype`, `version`, `username`, `tags`, etc.)
+- `metadata.links` — a record mapping link group IDs to arrays of `ApiLink` objects describing before/after relationships between features
+- `metadata.changesets` — an array of OSM changeset objects
+
+## Development
 
 ### Prerequisites
 
 - Node.js (v20.19+ or v22.12+)
 - Yarn 2+ package manager
 
-### Installation
+### Setup
 
 1. **Set up environment variables**
 
@@ -21,13 +116,13 @@ A Vue-based UI component for visualizing and interacting with OpenStreetMap logi
 
 Update `.env.local` with your configuration values.
 
-3. **Install dependencies**
+2. **Install dependencies**
 
 ```bash
    yarn install
 ```
 
-4. **Start the development server**
+3. **Start the development server**
 
 ```bash
    yarn dev

--- a/README.md
+++ b/README.md
@@ -60,21 +60,19 @@ A scoped slot exposed on each feature group, allowing custom rendering of tag di
 
 Slot props (always present):
 
-| Prop     | Type      | Description                  |
-| -------- | --------- | ---------------------------- |
-| `date`   | `string`  | The feature's creation date. |
-| `diff`   | `Actions` | The tag diff actions.        |
-| `reason` | `Reason`  | The conflation reason.       |
+| Prop     | Type                     | Description                                                                                                               |
+| -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `date`   | `string`                 | The feature's creation date.                                                                                              |
+| `diff`   | `Actions`                | The tag diff actions.                                                                                                     |
+| `reason` | `Reason`                 | The conflation reason.                                                                                                    |
+| `src`    | `IFeature['properties']` | Source feature properties. On "before" features this is the feature itself; on "after" it is the linked "before" feature. |
 
 Additional slot props on "after" features only:
 
-| Prop    | Type                     | Description                            |
-| ------- | ------------------------ | -------------------------------------- |
-| `title` | `string`                 | A label for the tag diff.              |
-| `dst`   | `IFeature['properties']` | Destination (after) feature properties |
-| `src`   | `IFeature['properties']` | Source (before) feature properties.    |
-
-On "before" features, `src` is the feature's own properties.
+| Prop    | Type                     | Description                             |
+| ------- | ------------------------ | --------------------------------------- |
+| `title` | `string`                 | A label for the tag diff.               |
+| `dst`   | `IFeature['properties']` | Destination (after) feature properties. |
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ import '@teritorio/openstreetmap-logical-history-component/style.css'
 import type { ApiResponse } from '@teritorio/openstreetmap-logical-history-component'
 import { LoCha } from '@teritorio/openstreetmap-logical-history-component'
 import { ref } from 'vue'
-import '@teritorio/openstreetmap-logical-history-component/style.css'
 
 const data = ref<ApiResponse>()
 
@@ -59,16 +58,23 @@ const data = ref<ApiResponse>()
 
 A scoped slot exposed on each feature group, allowing custom rendering of tag diffs.
 
-Slot props:
+Slot props (always present):
 
-| Prop     | Type                     | Description                                             |
-| -------- | ------------------------ | ------------------------------------------------------- |
-| `date`   | `string`                 | The feature's creation date.                            |
-| `title`  | `string`                 | A label for the tag diff (present on "after" features). |
-| `diff`   | `Actions`                | The tag diff actions.                                   |
-| `src`    | `IFeature['properties']` | Source (before) feature properties.                     |
-| `dst`    | `IFeature['properties']` | Destination (after) feature properties.                 |
-| `reason` | `Reason`                 | The conflation reason for this link.                    |
+| Prop     | Type      | Description                  |
+| -------- | --------- | ---------------------------- |
+| `date`   | `string`  | The feature's creation date. |
+| `diff`   | `Actions` | The tag diff actions.        |
+| `reason` | `Reason`  | The conflation reason.       |
+
+Additional slot props on "after" features only:
+
+| Prop    | Type                     | Description                            |
+| ------- | ------------------------ | -------------------------------------- |
+| `title` | `string`                 | A label for the tag diff.              |
+| `dst`   | `IFeature['properties']` | Destination (after) feature properties |
+| `src`   | `IFeature['properties']` | Source (before) feature properties.    |
+
+On "before" features, `src` is the feature's own properties.
 
 ### Types
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
-    }
+    },
+    "./style.css": "./dist/index.css"
   },
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "style": "./dist/index.css",
   "files": [
     "dist"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,15 @@
 export { default as LoCha } from './components/LoCha/LoCha.vue'
+
+export type {
+  Action,
+  Actions,
+  ActionType,
+  ActionTypeOptions,
+  ApiLink,
+  ApiLinkGroups,
+  ApiResponse,
+  IFeature,
+  Reason,
+  ReasonGeom,
+  ReasonTags,
+} from './composables/useApi'


### PR DESCRIPTION
## Summary
- Export consumer-facing types (`ApiResponse`, `IFeature`, `Reason`, `Actions`, etc.) from `src/index.ts`
- Add `./style.css` export and top-level `style` field to `package.json`
- Restructure README with a new **Usage** section covering installation, peer deps, importing, props, slots, types, and `ApiResponse` shape

## Test plan
- [x] `yarn build` succeeds and `dist/index.d.ts` contains all exported types
- [x] `yarn lint` passes
- [x] `yarn test --run` passes (36/36)
- [ ] Verify README renders correctly on GitHub

Closes #22