### PR TITLE
refactor: remove unused @vueuse/core and move @sentry/vite-plugin to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "vue": "^3.5.13"
   },
   "dependencies": {
-    "@sentry/vite-plugin": "^5.1.1",
     "@sentry/vue": "^10.44.0",
     "@turf/area": "^7.3.4",
     "@turf/bbox": "^7.3.4",
@@ -57,7 +56,6 @@
     "@turf/envelope": "^7.3.4",
     "@turf/helpers": "^7.3.4",
     "@vueuse/components": "^14.2.1",
-    "@vueuse/core": "^14.2.1",
     "diff": "^8.0.3",
     "underscore": "^1.13.8",
     "vue-router": "^5.0.3"
@@ -66,6 +64,7 @@
     "@antfu/eslint-config": "^7.7.3",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@sentry/vite-plugin": "^5.1.1",
     "@types/underscore": "^1.13.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,7 +1718,6 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     "@vue/tsconfig": "npm:^0.9.0"
     "@vueuse/components": "npm:^14.2.1"
-    "@vueuse/core": "npm:^14.2.1"
     diff: "npm:^8.0.3"
     eslint: "npm:^10.0.3"
     eslint-plugin-format: "npm:^2.0.1"
@@ -2639,7 +2638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vueuse/core@npm:14.2.1, @vueuse/core@npm:^14.2.1":
+"@vueuse/core@npm:14.2.1":
   version: 14.2.1
   resolution: "@vueuse/core@npm:14.2.1"
   dependencies:


### PR DESCRIPTION
## Summary
- Remove `@vueuse/core` from dependencies (only `@vueuse/components` is used)
- Move `@sentry/vite-plugin` from `dependencies` to `devDependencies` (build-time only)

Closes #24

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn build` produces correct output
- [x] `yarn test` — all 36 tests pass