### PR TITLE
refactor: remove dead code selectedFeatureId and _resetGroup

### DIFF
--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -61,7 +61,6 @@ export interface LoCha {
 
 // Internal state variables
 const loCha = ref<ApiResponse>()
-const selectedFeatureId = ref<number>()
 const groups = ref<LoChaGroup[]>([])
 
 /**
@@ -119,11 +118,6 @@ export function useLoCha(): LoCha {
    */
   function _resetState(): void {
     loCha.value = undefined
-    _resetGroup()
-  }
-
-  function _resetGroup(): void {
-    selectedFeatureId.value = undefined
   }
 
   return {


### PR DESCRIPTION
## Summary
- Remove unused `selectedFeatureId` ref that was never read or written
- Remove `_resetGroup()` which only reset the unused ref
- Simplify `_resetState()` accordingly

Closes #25

## Test plan
- [x] All 36 tests pass
- [x] No references to removed code anywhere in codebase