### PR TITLE
refactor: extract shared constants for map style URL and colors

### DIFF
--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -6,7 +6,7 @@ import { loChaColors, useLoCha } from '@/composables/useLoCha'
 import { formatDate } from '@/utils/date-format'
 
 const { groups } = useLoCha()
-const selectedBorderColor = loChaColors.delete
+const highlightBorderColor = loChaColors.delete
 const route = useRoute()
 const currentHash = ref<string>()
 
@@ -125,7 +125,7 @@ function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {})
 }
 
 .locha-group-list > ul > li.selected .locha-group {
-  border-color: v-bind(selectedBorderColor);
+  border-color: v-bind(highlightBorderColor);
 }
 
 .locha-group {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -2,10 +2,11 @@
 import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
-import { useLoCha } from '@/composables/useLoCha'
+import { loChaColors, useLoCha } from '@/composables/useLoCha'
 import { formatDate } from '@/utils/date-format'
 
 const { groups } = useLoCha()
+const selectedBorderColor = loChaColors.delete
 const route = useRoute()
 const currentHash = ref<string>()
 
@@ -124,7 +125,7 @@ function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {})
 }
 
 .locha-group-list > ul > li.selected .locha-group {
-  border-color: red;
+  border-color: v-bind(selectedBorderColor);
 }
 
 .locha-group {

--- a/src/components/MapBbox.vue
+++ b/src/components/MapBbox.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import maplibre from 'maplibre-gl'
 import { onMounted, shallowRef, watch } from 'vue'
+import { MAP_STYLE_URL } from '@/constants/map'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
 const props = defineProps<{
@@ -13,8 +14,6 @@ const emit = defineEmits<{
 
 const map = shallowRef<maplibre.Map | null>(null)
 let ignoreNextPropUpdate = false
-
-const MAP_STYLE_URL = 'https://maps.cartoway.com/styles/positron/style.json'
 
 function fitMapToBbox(bbox: string): void {
   if (!map.value)

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -12,6 +12,7 @@ import { vIntersectionObserver } from '@vueuse/components'
 import maplibre from 'maplibre-gl'
 import { shallowRef, watch } from 'vue'
 import { loChaColors } from '@/composables/useLoCha'
+import { MAP_STYLE_URL, NO_GEOM_COLOR } from '@/constants/map'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
 const props = defineProps<{
@@ -28,7 +29,6 @@ type MapMouseEventWithFeatures = MapMouseEvent & {
 
 const BBOX_SOURCE_ID = 'bbox'
 const SOURCE_ID = 'lochas'
-const MAP_STYLE_URL = 'https://maps.cartoway.com/styles/positron/style.json'
 const LAYERS = {
   Bbox: {
     id: 'bbox-layer',
@@ -69,7 +69,7 @@ const LAYERS = {
       'fill-color': [
         'case',
         ['==', ['get', 'geom'], false],
-        '#f4f4f5',
+        NO_GEOM_COLOR,
         ['==', ['get', 'is_new'], true],
         loChaColors.new,
         ['==', ['get', 'deleted'], true],
@@ -90,7 +90,7 @@ const LAYERS = {
       'line-color': [
         'case',
         ['==', ['get', 'geom'], false],
-        '#f4f4f5',
+        NO_GEOM_COLOR,
         ['==', ['get', 'is_new'], true],
         loChaColors.new,
         ['==', ['get', 'deleted'], true],
@@ -169,7 +169,7 @@ const LAYERS = {
       'circle-color': [
         'case',
         ['==', ['get', 'geom'], false],
-        '#f4f4f5',
+        NO_GEOM_COLOR,
         ['==', ['get', 'is_new'], true],
         loChaColors.new,
         ['==', ['get', 'deleted'], true],

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,0 +1,2 @@
+export const MAP_STYLE_URL = 'https://maps.cartoway.com/styles/positron/style.json'
+export const NO_GEOM_COLOR = '#f4f4f5'


### PR DESCRIPTION
## Summary
- Create `src/constants/map.ts` with `MAP_STYLE_URL` and `NO_GEOM_COLOR`
- Replace duplicated map style URL in `VMap.vue` and `MapBbox.vue`
- Replace hardcoded `#f4f4f5` in `VMap.vue` layers with `NO_GEOM_COLOR`
- Use `loChaColors.delete` via CSS `v-bind` instead of hardcoded `red` in `LoChaGroupList`

Closes #26

## Test plan
- [x] All 36 tests pass
- [x] No hardcoded map style URL remaining in components
- [x] `NO_GEOM_COLOR` used consistently in all 3 map layer definitions