### PR TITLE
refactor: centralize feature filtering in useLoCha composable

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -10,18 +10,10 @@ defineProps<{
   features: LoChaGroup
 }>()
 
-const { loCha } = useLoCha()
+const { loCha, getBeforeFeatures, getAfterFeatures } = useLoCha()
 
 if (!loCha.value)
   throw new Error('LoCha is empty.')
-
-function getBeforeFeatures(features: IFeature[]) {
-  return features.filter(feature => feature.properties.is_before)
-}
-
-function getAfterFeatures(features: IFeature[]) {
-  return features.filter(feature => feature.properties.is_after || feature.properties.is_new)
-}
 
 function getDiffs(
   feature: IFeature,

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -57,6 +57,8 @@ export interface LoCha {
   loCha: Ref<ApiResponse | undefined>
   setLoCha: (loCha: ApiResponse) => void
   getStatus: (feature: IFeature) => Status
+  getBeforeFeatures: (features: IFeature[]) => IFeature[]
+  getAfterFeatures: (features: IFeature[]) => IFeature[]
 }
 
 // Internal state variables
@@ -98,6 +100,14 @@ export function useLoCha(): LoCha {
     groups.value = groupFeaturesByLinks(data.features)
   }
 
+  function getBeforeFeatures(features: IFeature[]): IFeature[] {
+    return features.filter(feature => feature.properties.is_before)
+  }
+
+  function getAfterFeatures(features: IFeature[]): IFeature[] {
+    return features.filter(feature => feature.properties.is_after || feature.properties.is_new)
+  }
+
   function getStatus(feature: IFeature): Status {
     if (feature.properties.is_new) {
       return loChaStatus.new
@@ -132,5 +142,7 @@ export function useLoCha(): LoCha {
     groups,
     setLoCha,
     getStatus,
+    getBeforeFeatures,
+    getAfterFeatures,
   }
 }


### PR DESCRIPTION
## Summary
- Move `getBeforeFeatures()` and `getAfterFeatures()` from `LoChaGroup.vue` into the `useLoCha` composable
- Export both functions from the composable interface
- Update `LoChaGroup.vue` to use the composable functions

Single source of truth for feature status filtering logic.

Closes #27

## Test plan
- [x] All 36 tests pass
- [x] Feature filtering logic unchanged (same conditions)