### PR TITLE
refactor: extract OSM link URL builders to utility module

### DIFF
--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -2,6 +2,7 @@
 import type { IFeature } from '@/composables/useApi'
 import { computed } from 'vue'
 import { loChaColors, useLoCha } from '@/composables/useLoCha'
+import { getDeepHistoryUrl, getJosmUrl, getOsmHistoryUrl, getOsmHistoryViewerUrl, getOsmUserUrl } from '@/utils/osm-links'
 
 const props = defineProps<{
   feature: IFeature
@@ -30,7 +31,7 @@ const color = computed(() => loChaColors[status.value])
     <header>
       <div class="wrap">
         <a
-          :href="`https://www.openstreetmap.org/${feature.properties.objtype}/${feature.properties.id}/history`"
+          :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
           title="OSM History"
           target="_blank"
           @click.stop
@@ -53,7 +54,7 @@ const color = computed(() => loChaColors[status.value])
         📅 {{ props.feature.properties.created }}
       </p>
       <a
-        :href="`https://www.openstreetmap.org/user/${feature.properties.username}`"
+        :href="getOsmUserUrl(feature.properties.username)"
         :title="`View ${feature.properties.username} OSM profile`"
         target="_blank"
         @click.stop
@@ -64,7 +65,7 @@ const color = computed(() => loChaColors[status.value])
     <slot name="tags-diff" />
     <div class="actions">
       <a
-        :href="`https://www.openstreetmap.org/${feature.properties.objtype}/${feature.properties.id}/history`"
+        :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
         type="button"
         title="Edit in OSM iD"
         target="_blank"
@@ -73,7 +74,7 @@ const color = computed(() => loChaColors[status.value])
         OSM iD
       </a>
       <a
-        :href="`http://127.0.0.1:8111/load_object?objects=${feature.properties.objtype[0]}${feature.properties.id}`"
+        :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
         type="button"
         title="Edit in JOSM"
         target="hidden_josm_target"
@@ -82,7 +83,7 @@ const color = computed(() => loChaColors[status.value])
         JOSM
       </a>
       <a
-        :href="`https://osmlab.github.io/osm-deep-history/#/${feature.properties.objtype}/${feature.properties.id}`"
+        :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
         type="button"
         title="OSM Deep History"
         target="_blank"
@@ -91,7 +92,7 @@ const color = computed(() => loChaColors[status.value])
         Deep H
       </a>
       <a
-        :href="`https://pewu.github.io/osm-history/#/${feature.properties.objtype}/${feature.properties.id}`"
+        :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
         type="button"
         title="OSM History Viewer"
         target="_blank"

--- a/src/utils/osm-links.ts
+++ b/src/utils/osm-links.ts
@@ -3,7 +3,7 @@ export function getOsmHistoryUrl(objtype: string, id: number): string {
 }
 
 export function getOsmUserUrl(username: string): string {
-  return `https://www.openstreetmap.org/user/${username}`
+  return `https://www.openstreetmap.org/user/${encodeURIComponent(username)}`
 }
 
 export function getJosmUrl(objtype: string, id: number): string {

--- a/src/utils/osm-links.ts
+++ b/src/utils/osm-links.ts
@@ -1,0 +1,19 @@
+export function getOsmHistoryUrl(objtype: string, id: number): string {
+  return `https://www.openstreetmap.org/${objtype}/${id}/history`
+}
+
+export function getOsmUserUrl(username: string): string {
+  return `https://www.openstreetmap.org/user/${username}`
+}
+
+export function getJosmUrl(objtype: string, id: number): string {
+  return `http://127.0.0.1:8111/load_object?objects=${objtype[0]}${id}`
+}
+
+export function getDeepHistoryUrl(objtype: string, id: number): string {
+  return `https://osmlab.github.io/osm-deep-history/#/${objtype}/${id}`
+}
+
+export function getOsmHistoryViewerUrl(objtype: string, id: number): string {
+  return `https://pewu.github.io/osm-history/#/${objtype}/${id}`
+}


### PR DESCRIPTION
## Summary
- Create `src/utils/osm-links.ts` with helpers for OSM History, JOSM, Deep History, OSM History Viewer, and user profile URLs
- Replace all inline URL construction in `LoChaObject.vue`

Closes #28

## Test plan
- [x] All 36 tests pass
- [x] No hardcoded OSM URLs remaining in components