### PR TITLE
refactor: use Symbol injection key for reasonCollapsed

### DIFF
--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -3,6 +3,7 @@ import type { ApiResponse } from '@/composables/useApi'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
+import { REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 
 const props = withDefaults(defineProps<{
   data?: ApiResponse
@@ -11,7 +12,7 @@ const props = withDefaults(defineProps<{
   reasonCollapsed: true,
 })
 
-provide('reasonCollapsed', props.reasonCollapsed)
+provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
 
 const {
   featureCount,

--- a/src/components/LoCha/LoChaReason.vue
+++ b/src/components/LoCha/LoChaReason.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Reason } from '@/composables/useApi'
 import { computed, inject, ref } from 'vue'
+import { REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 
 const props = defineProps<{
   reason: Reason
@@ -24,8 +25,8 @@ function formatNumericValue(key: string, val: number | string): number | string 
   }
 }
 
-const defaultCollapsedState = inject<boolean>('reasonCollapsed')
-const isReasonCollapsed = ref<boolean>(defaultCollapsedState!)
+const defaultCollapsedState = inject(REASON_COLLAPSED_KEY, true)
+const isReasonCollapsed = ref(defaultCollapsedState)
 
 function toggleReason() {
   isReasonCollapsed.value = !isReasonCollapsed.value

--- a/src/constants/injectionKeys.ts
+++ b/src/constants/injectionKeys.ts
@@ -1,0 +1,3 @@
+import type { InjectionKey } from 'vue'
+
+export const REASON_COLLAPSED_KEY: InjectionKey<boolean> = Symbol('reasonCollapsed')


### PR DESCRIPTION
## Summary
- Create shared `InjectionKey<boolean>` in `src/constants/injectionKeys.ts`
- Use typed Symbol key in `LoCha.vue` (provide) and `LoChaReason.vue` (inject)
- Provide default value (`true`) to `inject()`, eliminating the non-null assertion `!`

Closes #31

## Test plan
- [x] All 36 tests pass
- [x] Type-safe injection, no runtime risk if injection is missing