### PR TITLE
refactor: move preset data out of MapFilters component

### DIFF
--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import type { FormData, Preset } from '@/types'
+import type { FormData } from '@/types'
 import { reactive, ref, shallowRef, useTemplateRef, watchEffect } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import MapBbox from '@/components/MapBbox.vue'
+import { presets } from '@/data/presets'
 
 const props = withDefaults(
   defineProps<{
@@ -18,34 +19,6 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: 'submit', payload: FormData): void
 }>()
-
-// TODO: move presets to another file.
-const presets = [{
-  title: 'Parking - (Points / Lines)',
-  dateStart: new Date('2023-08-01').toISOString().slice(0, 16),
-  dateEnd: new Date('2023-09-30').toISOString().slice(0, 16),
-  bbox: '-1.4865185506147705,43.57582751611194,-1.4857594854635559,43.57668833005737',
-}, {
-  title: 'Bridge Construction Ends - (Lines)',
-  dateStart: new Date('2024-07-01').toISOString().slice(0, 16),
-  dateEnd: new Date('2024-08-01').toISOString().slice(0, 16),
-  bbox: '-0.5420824675324966,44.82039347351967,-0.5393090634110976,44.82208861548204',
-}, {
-  title: 'Remap Buildings - (Surfaces)',
-  dateStart: new Date('2024-12-10').toISOString().slice(0, 16),
-  dateEnd: new Date('2024-12-15').toISOString().slice(0, 16),
-  bbox: '-1.6537454710167148,42.685107065011486,-1.6509720668953156,42.68686379572838',
-}, {
-  title: 'Move Node Tags to Way',
-  dateStart: new Date('2025-09-04').toISOString().slice(0, 16),
-  dateEnd: new Date('2025-10-04').toISOString().slice(0, 16),
-  bbox: '1.890431110148569,49.126892511822376,1.8909489817189638,49.127209658721114',
-}, {
-  title: 'Split highway + Refs',
-  dateStart: new Date('2024-12-12').toISOString().slice(0, 16),
-  dateEnd: new Date('2024-12-13').toISOString().slice(0, 16),
-  bbox: '-1.405801462176413,43.33124243726789,-1.3963476233167,43.33767765881896',
-}] satisfies Preset[]
 
 const formRef = ref<InstanceType<typeof HTMLFormElement>>()
 const formValues = reactive<FormData>({

--- a/src/data/presets.ts
+++ b/src/data/presets.ts
@@ -1,0 +1,28 @@
+import type { Preset } from '@/types'
+
+export const presets: Preset[] = [{
+  title: 'Parking - (Points / Lines)',
+  dateStart: new Date('2023-08-01').toISOString().slice(0, 16),
+  dateEnd: new Date('2023-09-30').toISOString().slice(0, 16),
+  bbox: '-1.4865185506147705,43.57582751611194,-1.4857594854635559,43.57668833005737',
+}, {
+  title: 'Bridge Construction Ends - (Lines)',
+  dateStart: new Date('2024-07-01').toISOString().slice(0, 16),
+  dateEnd: new Date('2024-08-01').toISOString().slice(0, 16),
+  bbox: '-0.5420824675324966,44.82039347351967,-0.5393090634110976,44.82208861548204',
+}, {
+  title: 'Remap Buildings - (Surfaces)',
+  dateStart: new Date('2024-12-10').toISOString().slice(0, 16),
+  dateEnd: new Date('2024-12-15').toISOString().slice(0, 16),
+  bbox: '-1.6537454710167148,42.685107065011486,-1.6509720668953156,42.68686379572838',
+}, {
+  title: 'Move Node Tags to Way',
+  dateStart: new Date('2025-09-04').toISOString().slice(0, 16),
+  dateEnd: new Date('2025-10-04').toISOString().slice(0, 16),
+  bbox: '1.890431110148569,49.126892511822376,1.8909489817189638,49.127209658721114',
+}, {
+  title: 'Split highway + Refs',
+  dateStart: new Date('2024-12-12').toISOString().slice(0, 16),
+  dateEnd: new Date('2024-12-13').toISOString().slice(0, 16),
+  bbox: '-1.405801462176413,43.33124243726789,-1.3963476233167,43.33767765881896',
+}]


### PR DESCRIPTION
## Summary
- Create `src/data/presets.ts` with example presets array
- Import presets in `MapFilters.vue` instead of defining inline
- Resolves existing TODO comment in the code

Closes #35

## Test plan
- [x] All 36 tests pass