### PR TITLE
refactor: reorganize TypeScript type definitions

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { ApiResponse } from '@/composables/useApi'
-import type { FormData } from '@/types'
+import type { ApiResponse, FormData } from '@/types'
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import LoCha from '@/components/LoCha/LoCha.vue'

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiResponse } from '@/composables/useApi'
+import type { ApiResponse } from '@/types'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Change } from 'diff'
-import type { ApiLink, IFeature } from '@/composables/useApi'
+import type { ApiLink, IFeature } from '@/types'
 import { diffChars } from 'diff'
 import { groupBy, sortBy, uniq } from 'underscore'
 import { computed } from 'vue'

--- a/src/components/LoCha/LoChaDiffTag.vue
+++ b/src/components/LoCha/LoChaDiffTag.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Action } from '@/composables/useApi'
+import type { Action } from '@/types'
 import { loChaColors } from '@/composables/useLoCha'
 
 defineProps<{

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature } from '@/composables/useApi'
-import type { LoChaGroup } from '@/composables/useLoCha'
+import type { ApiLink, IFeature, LoChaGroup } from '@/types'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { useLoCha } from '@/composables/useLoCha'

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { IFeature } from '@/composables/useApi'
+import type { IFeature } from '@/types'
 import { computed } from 'vue'
 import { loChaColors, useLoCha } from '@/composables/useLoCha'
 import { getDeepHistoryUrl, getJosmUrl, getOsmHistoryUrl, getOsmHistoryViewerUrl, getOsmUserUrl } from '@/utils/osm-links'

--- a/src/components/LoCha/LoChaReason.vue
+++ b/src/components/LoCha/LoChaReason.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Reason } from '@/composables/useApi'
+import type { Reason } from '@/types'
 import { computed, inject, ref } from 'vue'
 import { REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { BBox } from 'geojson'
 import type { LngLatLike, MapMouseEvent } from 'maplibre-gl'
-import type { LoChaGroup } from '@/composables/useLoCha'
+import type { LoChaGroup } from '@/types'
 import turfBbox from '@turf/bbox'
 import { featureCollection as turfFeatureCollection } from '@turf/helpers'
 import { vIntersectionObserver } from '@vueuse/components'

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -1,7 +1,9 @@
 import type { Reactive, Ref } from 'vue'
-import type { Error } from '@/types'
+import type { ApiResponse, Error } from '@/types'
 import { reactive, ref } from 'vue'
 import { transformFeatures } from '@/utils/feature-transform'
+
+export type { Action, Actions, ActionType, ActionTypeOptions, ApiLink, ApiLinkGroups, ApiResponse, IFeature, Reason, ReasonGeom, ReasonTags } from '@/types'
 
 /**
  * Interface representing the reactive state and methods for handling API interactions.
@@ -40,97 +42,6 @@ interface ApiComposable {
    * Resets the error state
    */
   resetError: () => void
-}
-
-type ObjectType = 'node' | 'way' | 'relation'
-
-export type ActionType = 'accept' | 'reject'
-
-export type ActionTypeOptions = Record<string, string | string[] | object>
-
-export type Action = [string, ActionType | null, ActionTypeOptions | null]
-
-export type Actions = Record<string, Action[]>
-
-export interface ReasonGeom {
-  max_distance?: number
-  min_distance?: number
-  score: number
-  reason: string
-}
-
-export interface ReasonTags {
-  score: number
-  reason: string
-}
-
-export interface Reason {
-  geom: ReasonGeom
-  tags: ReasonTags
-  conflate: string
-}
-
-interface Changeset {
-  id: number
-  created_at: string
-  closed_at: string
-  open: boolean
-  user: string
-  uid: number
-  minlat: number
-  minlon: number
-  maxlat: number
-  maxlon: number
-  comments_count: number
-  changes_count: number
-  tags: Record<string, string>
-}
-
-export type ApiLinkGroups = Record<number, ApiLink[]>
-
-/**
- * Interface representing a link in the API metadata.
- * A link typically points to a feature.
- */
-export interface ApiLink {
-  action: ActionType
-  before?: number
-  after?: number
-  diff_attribs?: Actions
-  diff_tags?: Actions
-  conflation_reason: Reason
-}
-
-export interface IFeature extends GeoJSON.Feature {
-  id: number
-  properties: {
-    objtype: ObjectType
-    id: number
-    geom_distance: number | null
-    geom: boolean
-    deleted: boolean
-    links: number
-    members?: null
-    version: number
-    username: string
-    created: string
-    tags: Record<string, string>
-    is_before?: boolean
-    is_after?: boolean
-    is_new?: boolean
-  }
-}
-
-/**
- * Interface representing the API response.
- * Extends `GeoJSON.FeatureCollection` to represent geographic data and includes additional metadata.
- */
-export interface ApiResponse extends GeoJSON.FeatureCollection {
-  features: IFeature[]
-  metadata: {
-    links: ApiLinkGroups
-    changesets: Changeset[]
-  }
 }
 
 /**

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -1,33 +1,7 @@
-import type { ComputedRef, Ref } from 'vue'
-import type { ApiResponse, IFeature } from '@/composables/useApi'
+import type { ApiResponse, Color, IFeature, LoChaGroup, LoCha as LoChaInterface, Status } from '@/types'
 import { computed, ref } from 'vue'
 
-/**
- * The possible statuses for features in the system.
- * - 'new': New features.
- * - 'delete': Deleted features.
- * - 'update': Updated features.
- */
-export type Status = 'new' | 'delete' | 'updateBefore' | 'updateAfter'
-
-/**
- * The Color type defines colors based on feature status.
- * - 'new' maps to '#52c41a'
- * - 'delete' maps to '#FF0000'
- * - 'updateBefore' maps to '#FFA479'
- * - 'updateAfter' maps to '#F2BE00'
- */
-export type Color = {
-  [key in Status]: key extends 'new'
-    ? '#52c41a'
-    : key extends 'delete'
-      ? '#FF0000'
-      : key extends 'updateBefore'
-        ? '#FFA479'
-        : '#F2BE00'
-}
-
-export type LoChaGroup = IFeature[]
+export type { Color, LoCha, LoChaGroup, Status } from '@/types'
 
 /**
  * A predefined object that maps status types to corresponding color codes.
@@ -47,20 +21,6 @@ export const loChaStatus = Object.fromEntries(
   ['new', 'delete', 'updateAfter', 'updateBefore'].map(key => [key, key]),
 ) as Record<Status, Status>
 
-/**
- * The LoCha interface defines the structure of the LoCha state,
- * which includes various references and computed values to track the features and metadata.
- */
-export interface LoCha {
-  featureCount: ComputedRef<number | undefined>
-  groups: Ref<LoChaGroup[]>
-  loCha: Ref<ApiResponse | undefined>
-  setLoCha: (loCha: ApiResponse) => void
-  getStatus: (feature: IFeature) => Status
-  getBeforeFeatures: (features: IFeature[]) => IFeature[]
-  getAfterFeatures: (features: IFeature[]) => IFeature[]
-}
-
 // Internal state variables
 const loCha = ref<ApiResponse>()
 const groups = ref<LoChaGroup[]>([])
@@ -70,7 +30,7 @@ const groups = ref<LoChaGroup[]>([])
  * This includes tracking features, metadata, and updating state based on new data.
  * @returns An object containing reactive references and functions for working with LoCha data.
  */
-export function useLoCha(): LoCha {
+export function useLoCha(): LoChaInterface {
   /**
    * A computed reference to count the number of features in the LoCha response.
    * @returns The number of features in the LoCha response, or undefined if no data is available.

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,4 @@ export type {
   Reason,
   ReasonGeom,
   ReasonTags,
-} from './composables/useApi'
+} from './types'

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,90 @@
+export type ObjectType = 'node' | 'way' | 'relation'
+
+export type ActionType = 'accept' | 'reject'
+
+export type ActionTypeOptions = Record<string, string | string[] | object>
+
+export type Action = [string, ActionType | null, ActionTypeOptions | null]
+
+export type Actions = Record<string, Action[]>
+
+export interface ReasonGeom {
+  max_distance?: number
+  min_distance?: number
+  score: number
+  reason: string
+}
+
+export interface ReasonTags {
+  score: number
+  reason: string
+}
+
+export interface Reason {
+  geom: ReasonGeom
+  tags: ReasonTags
+  conflate: string
+}
+
+export interface Changeset {
+  id: number
+  created_at: string
+  closed_at: string
+  open: boolean
+  user: string
+  uid: number
+  minlat: number
+  minlon: number
+  maxlat: number
+  maxlon: number
+  comments_count: number
+  changes_count: number
+  tags: Record<string, string>
+}
+
+export type ApiLinkGroups = Record<number, ApiLink[]>
+
+/**
+ * Interface representing a link in the API metadata.
+ * A link typically points to a feature.
+ */
+export interface ApiLink {
+  action: ActionType
+  before?: number
+  after?: number
+  diff_attribs?: Actions
+  diff_tags?: Actions
+  conflation_reason: Reason
+}
+
+export interface IFeature extends GeoJSON.Feature {
+  id: number
+  properties: {
+    objtype: ObjectType
+    id: number
+    geom_distance: number | null
+    geom: boolean
+    deleted: boolean
+    links: number
+    members?: null
+    version: number
+    username: string
+    created: string
+    tags: Record<string, string>
+    is_before?: boolean
+    is_after?: boolean
+    is_new?: boolean
+  }
+}
+
+/**
+ * Interface representing the API response.
+ * Extends `GeoJSON.FeatureCollection` to represent geographic data and includes additional metadata.
+ */
+export interface ApiResponse extends GeoJSON.FeatureCollection {
+  features: IFeature[]
+  metadata: {
+    links: ApiLinkGroups
+    changesets: Changeset[]
+  }
+}

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,43 @@
+import type { ComputedRef, Ref } from 'vue'
+import type { ApiResponse, IFeature } from './api'
+
+/**
+ * The possible statuses for features in the system.
+ * - 'new': New features.
+ * - 'delete': Deleted features.
+ * - 'update': Updated features.
+ */
+export type Status = 'new' | 'delete' | 'updateBefore' | 'updateAfter'
+
+/**
+ * The Color type defines colors based on feature status.
+ * - 'new' maps to '#52c41a'
+ * - 'delete' maps to '#FF0000'
+ * - 'updateBefore' maps to '#FFA479'
+ * - 'updateAfter' maps to '#F2BE00'
+ */
+export type Color = {
+  [key in Status]: key extends 'new'
+    ? '#52c41a'
+    : key extends 'delete'
+      ? '#FF0000'
+      : key extends 'updateBefore'
+        ? '#FFA479'
+        : '#F2BE00'
+}
+
+export type LoChaGroup = IFeature[]
+
+/**
+ * The LoCha interface defines the structure of the LoCha state,
+ * which includes various references and computed values to track the features and metadata.
+ */
+export interface LoCha {
+  featureCount: ComputedRef<number | undefined>
+  groups: Ref<LoChaGroup[]>
+  loCha: Ref<ApiResponse | undefined>
+  setLoCha: (loCha: ApiResponse) => void
+  getStatus: (feature: IFeature) => Status
+  getBeforeFeatures: (features: IFeature[]) => IFeature[]
+  getAfterFeatures: (features: IFeature[]) => IFeature[]
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,3 @@
-export interface FormData {
-  dateStart: string
-  dateEnd?: string
-  bbox: string
-}
-
-export interface Preset extends FormData {
-  title: string
-}
-
-export type ErrorType = 'error' | 'warning' | 'success' | 'info'
-
-export interface Error {
-  message?: string
-  type: ErrorType
-}
+export type * from './api'
+export type * from './domain'
+export * from './ui'

--- a/src/types/ui.ts
+++ b/src/types/ui.ts
@@ -1,0 +1,16 @@
+export interface FormData {
+  dateStart: string
+  dateEnd?: string
+  bbox: string
+}
+
+export interface Preset extends FormData {
+  title: string
+}
+
+export type ErrorType = 'error' | 'warning' | 'success' | 'info'
+
+export interface Error {
+  message?: string
+  type: ErrorType
+}

--- a/src/utils/feature-transform.ts
+++ b/src/utils/feature-transform.ts
@@ -1,4 +1,4 @@
-import type { ApiResponse } from '@/composables/useApi'
+import type { ApiResponse } from '@/types'
 import { area } from '@turf/area'
 import booleanEqual from '@turf/boolean-equal'
 

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -1,4 +1,4 @@
-import type { ActionType, ApiLink, ApiLinkGroups, ApiResponse, IFeature } from '@/composables/useApi'
+import type { ActionType, ApiLink, ApiLinkGroups, ApiResponse, IFeature } from '@/types'
 
 export function createFeature(overrides: Partial<IFeature> & { id: number }): IFeature {
   const { properties: propOverrides, ...rest } = overrides


### PR DESCRIPTION
## Summary
- Move type-only definitions from composables into dedicated `src/types/` modules (`api.ts`, `domain.ts`, `ui.ts`)
- Convert `src/types/index.ts` to a barrel re-exporting all type modules
- Update all component and test imports to use `@/types` instead of `@/composables/useApi` or `@/composables/useLoCha`
- Composables retain re-exports for backward compatibility

## Test plan
- [x] `yarn lint:fix` passes
- [x] `yarn build` produces valid library output
- [x] All 36 unit tests pass
- [ ] Verify no runtime regressions in the demo app

Closes #33