### PR TITLE
refactor: type slot props in LoCha component hierarchy

### DIFF
--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiResponse } from '@/types'
+import type { ApiResponse, TagsDiffSlotProps } from '@/types'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -11,6 +11,8 @@ const props = withDefaults(defineProps<{
 }>(), {
   reasonCollapsed: true,
 })
+
+defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature, LoChaGroup } from '@/types'
+import type { ApiLink, IFeature, LoChaGroup, TagsDiffSlotProps } from '@/types'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -8,6 +8,8 @@ defineProps<{
   index: number
   features: LoChaGroup
 }>()
+
+defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
 
 const { loCha, getBeforeFeatures, getAfterFeatures } = useLoCha()
 
@@ -52,15 +54,15 @@ function getTagsTitle(link: ApiLink): string {
         >
           <LoChaObject :feature="feature">
             <template #tags-diff>
-              <slot
-                v-for="(link, i) in getDiffs(feature, index)"
-                :key="i"
-                name="tags-diff"
-                :date="feature.properties.created"
-                :diff="link.diff_tags"
-                :src="feature.properties"
-                :reason="link.conflation_reason"
-              />
+              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                <slot
+                  name="tags-diff"
+                  :date="feature.properties.created"
+                  :diff="link.diff_tags"
+                  :src="feature.properties"
+                  :reason="link.conflation_reason"
+                />
+              </template>
             </template>
           </LoChaObject>
         </li>
@@ -74,17 +76,17 @@ function getTagsTitle(link: ApiLink): string {
         >
           <LoChaObject :feature="feature">
             <template #tags-diff>
-              <slot
-                v-for="(link, i) in getDiffs(feature, index)"
-                :key="i"
-                name="tags-diff"
-                :date="feature.properties.created"
-                :title="getTagsTitle(link)"
-                :diff="link.diff_tags"
-                :reason="link.conflation_reason"
-                :dst="feature.properties"
-                :src="getBeforeProperties(link)"
-              />
+              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                <slot
+                  name="tags-diff"
+                  :date="feature.properties.created"
+                  :title="getTagsTitle(link)"
+                  :diff="link.diff_tags"
+                  :reason="link.conflation_reason"
+                  :dst="feature.properties"
+                  :src="getBeforeProperties(link)"
+                />
+              </template>
             </template>
           </LoChaObject>
         </li>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import type { TagsDiffSlotProps } from '@/types'
 import { computed, nextTick, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors, useLoCha } from '@/composables/useLoCha'
 import { formatDate } from '@/utils/date-format'
+
+defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
 
 const { groups } = useLoCha()
 const highlightBorderColor = loChaColors.delete

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -8,6 +8,8 @@ const props = defineProps<{
   feature: IFeature
 }>()
 
+defineSlots<{ 'tags-diff': () => void }>()
+
 const { getStatus } = useLoCha()
 
 const status = computed(() => getStatus(props.feature))

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,4 +12,5 @@ export type {
   Reason,
   ReasonGeom,
   ReasonTags,
+  TagsDiffSlotProps,
 } from './types'

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { ApiResponse, IFeature } from './api'
+import type { Actions, ApiResponse, IFeature, Reason } from './api'
 
 /**
  * The possible statuses for features in the system.
@@ -27,6 +27,18 @@ export type Color = {
 }
 
 export type LoChaGroup = IFeature[]
+
+/**
+ * Props passed through the `tags-diff` slot across the LoCha component hierarchy.
+ */
+export interface TagsDiffSlotProps {
+  date: string
+  diff: Actions | undefined
+  src?: IFeature['properties']
+  dst?: IFeature['properties']
+  reason: Reason
+  title?: string
+}
 
 /**
  * The LoCha interface defines the structure of the LoCha state,


### PR DESCRIPTION
## Summary
- Add `TagsDiffSlotProps` interface in `src/types/domain.ts` for type-safe slot prop bindings
- Add `defineSlots` typing to `LoCha`, `LoChaGroupList`, `LoChaGroup`, and `LoChaObject` components
- Export `TagsDiffSlotProps` for library consumers via `src/index.ts`
- Move `v-for` from `<slot>` to wrapping `<template>` in `LoChaGroup` to avoid TS conflicts between `:key` directive and slot props

**Depends on:** #45 (reorganize type definitions)

## Test plan
- [x] `yarn lint:fix` passes
- [x] `yarn build` produces valid library output
- [x] All 36 unit tests pass
- [ ] Verify slot props are correctly typed when consuming the `LoCha` component

Closes #34