### PR TITLE
fix: correct lat/lng order in bbox polygon and placeholder

### DIFF
--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -95,7 +95,7 @@ function handleSubmit(): void {
           id="bbox"
           v-model="formValues.bbox"
           type="text"
-          placeholder="lat1, lon1, lat2, lon2"
+          placeholder="west, south, east, north"
           pattern="^-?\d+\.\d+,-?\d+\.\d+,-?\d+\.\d+,-?\d+\.\d+$"
           required
         >

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -100,11 +100,11 @@ function displayBbox(bbox: BBox): void {
       geometry: {
         type: 'Polygon',
         coordinates: [[
-          [bbox[1], bbox[0]],
-          [bbox[3], bbox[0]],
-          [bbox[3], bbox[2]],
-          [bbox[1], bbox[2]],
-          [bbox[1], bbox[0]],
+          [bbox[0], bbox[1]],
+          [bbox[2], bbox[1]],
+          [bbox[2], bbox[3]],
+          [bbox[0], bbox[3]],
+          [bbox[0], bbox[1]],
         ]],
       },
       properties: {},


### PR DESCRIPTION
## Summary

- Fix reversed coordinates in `displayBbox()` GeoJSON polygon — GeoJSON requires `[longitude, latitude]` but bbox indices were swapped, causing the bbox overlay to render at wrong map coordinates
- Update `MapFilters.vue` placeholder from `"lat1, lon1, lat2, lon2"` to `"lon1, lat1, lon2, lat2"` to match the actual expected input format (`west, south, east, north`)

Closes #48

## Test plan

- [ ] `yarn lint:fix` passes
- [ ] `yarn build` succeeds
- [ ] Visual check: bbox overlay renders at correct position on the demo map