### PR TITLE
fix: support multiple LoCha groups in a single ApiResponse

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature, LoChaGroup, TagsDiffSlotProps } from '@/types'
+import type { ApiLink, IFeature, TagsDiffSlotProps } from '@/types'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { useLoCha } from '@/composables/useLoCha'
 
-defineProps<{
-  index: number
-  features: LoChaGroup
+const props = defineProps<{
+  linkId: number
+  features: IFeature[]
 }>()
 
 defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
@@ -18,14 +18,13 @@ if (!loCha.value)
 
 function getDiffs(
   feature: IFeature,
-  index: number,
 ): ApiLink[] | undefined {
   if (feature.properties.is_before) {
-    const link = loCha.value!.metadata.links[index].find(link => link.before === feature.id || link.after === feature.id)
+    const link = loCha.value!.metadata.links[props.linkId].find(link => link.before === feature.id || link.after === feature.id)
     return link && [link]
   }
 
-  return loCha.value!.metadata.links[index].filter(link => link.before === feature.id || link.after === feature.id)
+  return loCha.value!.metadata.links[props.linkId].filter(link => link.before === feature.id || link.after === feature.id)
 }
 
 function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined {
@@ -54,7 +53,7 @@ function getTagsTitle(link: ApiLink): string {
         >
           <LoChaObject :feature="feature">
             <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+              <template v-for="(link, i) in getDiffs(feature)" :key="i">
                 <slot
                   name="tags-diff"
                   :date="feature.properties.created"
@@ -76,7 +75,7 @@ function getTagsTitle(link: ApiLink): string {
         >
           <LoChaObject :feature="feature">
             <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+              <template v-for="(link, i) in getDiffs(feature)" :key="i">
                 <slot
                   name="tags-diff"
                   :date="feature.properties.created"
@@ -92,7 +91,7 @@ function getTagsTitle(link: ApiLink): string {
         </li>
       </ul>
     </div>
-    <VMap :id="index" :features="features" :bbox="loCha?.bbox" />
+    <VMap :id="linkId" :features="features" :bbox="loCha?.bbox" />
   </div>
 </template>
 

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -68,9 +68,9 @@ function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {})
       <h2>After : {{ dateTo }}</h2>
     </header>
     <ul>
-      <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#group-${index}` }">
+      <li v-for="(group, index) in groups" :key="group.linkId" :class="{ selected: currentHash === `#group-${index}` }">
         <a class="anchor-button" :href="`#group-${index}`">🔗</a>
-        <LoChaGroup :id="`group-${index}`" :features="group" :index="index">
+        <LoChaGroup :id="`group-${index}`" :features="group.features" :link-id="group.linkId">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />
           </template>

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { BBox } from 'geojson'
 import type { LngLatLike, MapMouseEvent } from 'maplibre-gl'
-import type { LoChaGroup } from '@/types'
+import type { IFeature } from '@/types'
 import turfBbox from '@turf/bbox'
 import { featureCollection as turfFeatureCollection } from '@turf/helpers'
 import { vIntersectionObserver } from '@vueuse/components'
@@ -14,7 +14,7 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 
 const props = defineProps<{
   id: number
-  features: LoChaGroup
+  features: IFeature[]
   bbox?: GeoJSON.BBox
 }>()
 

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -38,14 +38,17 @@ export function useLoCha(): LoChaInterface {
   const featureCount = computed(() => loCha.value?.features.length)
 
   function groupFeaturesByLinks(features: IFeature[]): LoChaGroup[] {
-    return features.reduce((groups, feature) => {
+    const map = new Map<number, IFeature[]>()
+    for (const feature of features) {
       const linkId = feature.properties.links
-      if (!groups[linkId]) {
-        groups[linkId] = []
+      let group = map.get(linkId)
+      if (!group) {
+        group = []
+        map.set(linkId, group)
       }
-      groups[linkId].push(feature)
-      return groups
-    }, [] as LoChaGroup[])
+      group.push(feature)
+    }
+    return Array.from(map, ([linkId, features]) => ({ linkId, features }))
   }
 
   /**

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -26,7 +26,10 @@ export type Color = {
         : '#F2BE00'
 }
 
-export type LoChaGroup = IFeature[]
+export interface LoChaGroup {
+  linkId: number
+  features: IFeature[]
+}
 
 /**
  * Props passed through the `tags-diff` slot across the LoCha component hierarchy.

--- a/src/utils/feature-transform.ts
+++ b/src/utils/feature-transform.ts
@@ -25,7 +25,8 @@ export function transformFeatures(data: ApiResponse): ApiResponse['features'] {
     if (!link)
       throw new Error(`Feature ${feature.id} has no link.`)
 
-    const linkedFeature = data.features.find(f => (f.properties.links === feature.properties.links) && (f.id !== feature.id))
+    const linkedFeatureId = feature.id === link.before ? link.after : link.before
+    const linkedFeature = data.features.find(f => f.id === linkedFeatureId)
 
     if (linkedFeature?.geometry && feature.geometry) {
       feature.properties.geom = !booleanEqual(feature.geometry, linkedFeature.geometry)


### PR DESCRIPTION
## Summary

- Fix sparse array iteration in `groupFeaturesByLinks` — use a `Map` to build a dense array of `{ linkId, features }` objects instead of a sparse array indexed by link IDs
- Fix incorrect `linkedFeature` lookup in `transformFeatures` — use `ApiLink.before`/`ApiLink.after` IDs to find the specific linked feature instead of matching by `properties.links`
- Update `LoChaGroup` type, `LoChaGroupList`, `LoChaGroup`, and `VMap` components to pass and use `linkId` explicitly

Closes #52

## Test plan

- [x] `yarn build` succeeds
- [x] `yarn lint` passes
- [ ] Verify existing single-group demo still works
- [ ] Test with a multi-group `ApiResponse` payload