### PR TITLE
Handle array response format from Clearance API

### DIFF
--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -107,10 +107,10 @@ export function useApiConfig(): ApiComposable {
           throw new Error(message || res.statusText)
         }
 
-        return await res.json()
+        return await res.json() as ApiResponse | ApiResponse[]
       })
       .then((data) => {
-        const entry: ApiResponse = Array.isArray(data) ? data[0] : data
+        const entry = Array.isArray(data) ? data[0] : data
         return {
           ...entry,
           features: transformFeatures(entry),

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -111,6 +111,8 @@ export function useApiConfig(): ApiComposable {
       })
       .then((data) => {
         const entry = Array.isArray(data) ? data[0] : data
+        if (!entry)
+          throw new Error('Empty response from API')
         return {
           ...entry,
           features: transformFeatures(entry),

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -107,12 +107,15 @@ export function useApiConfig(): ApiComposable {
           throw new Error(message || res.statusText)
         }
 
-        return await res.json() as ApiResponse
+        return await res.json()
       })
-      .then(data => ({
-        ...data,
-        features: transformFeatures(data),
-      }))
+      .then((data) => {
+        const entry: ApiResponse = Array.isArray(data) ? data[0] : data
+        return {
+          ...entry,
+          features: transformFeatures(entry),
+        }
+      })
       .catch((err) => {
         setError({
           message: err.message,

--- a/tests/composables/useApi.spec.ts
+++ b/tests/composables/useApi.spec.ts
@@ -121,6 +121,22 @@ describe('useApi', () => {
       expect(error.message).toBeUndefined()
     })
 
+    it('unwraps array response and uses the first entry', async () => {
+      const mockResponse = createApiResponse([], {})
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([mockResponse]),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeDefined()
+      expect(result?.features).toEqual([])
+    })
+
     it('filters out undefined and empty params from the URL', async () => {
       const fetchSpy = vi.fn().mockResolvedValue({
         ok: true,

--- a/tests/composables/useApi.spec.ts
+++ b/tests/composables/useApi.spec.ts
@@ -122,11 +122,13 @@ describe('useApi', () => {
     })
 
     it('unwraps array response and uses the first entry', async () => {
-      const mockResponse = createApiResponse([], {})
+      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      const first = createApiResponse([feature], { 1: [createLink({ after: 10 })] })
+      const second = createApiResponse([], {})
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve([mockResponse]),
+        json: () => Promise.resolve([first, second]),
       }))
 
       const { useApiConfig } = await import('@/composables/useApi')
@@ -134,7 +136,23 @@ describe('useApi', () => {
 
       const result = await fetchData({ date_start: '2024-01-01' })
       expect(result).toBeDefined()
-      expect(result?.features).toEqual([])
+      expect(result?.features).toHaveLength(1)
+      expect(result?.features[0].id).toBe(10)
+    })
+
+    it('returns undefined and sets error on empty array response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      }))
+
+      const { useApiConfig } = await import('@/composables/useApi')
+      const { fetchData, error } = useApiConfig()
+
+      const result = await fetchData({ date_start: '2024-01-01' })
+      expect(result).toBeUndefined()
+      expect(error.message).toBe('Empty response from API')
+      expect(error.type).toBe('error')
     })
 
     it('filters out undefined and empty params from the URL', async () => {


### PR DESCRIPTION
## Summary
- Detect whether the Clearance API returns an array or single `ApiResponse` object
- Extract the first entry when an array is received, maintaining backward compatibility
- No changes to the component library — only the demo app's API layer is affected

Closes #55

## Test plan
- [x] `yarn lint` passes
- [x] `yarn test` — 36 tests pass
- [x] `yarn build` succeeds
- [ ] Point `VITE_API_ENDPOINT` to `https://clearance-dev.teritorio.xyz` and verify the demo loads