### PR TITLE
feat: adapt API types to new Clearance format

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -42,7 +42,7 @@ export interface Changeset {
   tags: Record<string, string>
 }
 
-export type ApiLinkGroups = Record<number, ApiLink[]>
+export type ApiLinkGroups = ApiLink[][]
 
 /**
  * Interface representing a link in the API metadata.
@@ -50,15 +50,15 @@ export type ApiLinkGroups = Record<number, ApiLink[]>
  */
 export interface ApiLink {
   action: ActionType
-  before?: number
-  after?: number
+  before?: string
+  after?: string
   diff_attribs?: Actions
   diff_tags?: Actions
   conflation_reason: Reason
 }
 
 export interface IFeature extends GeoJSON.Feature {
-  id: number
+  id: string
   properties: {
     objtype: ObjectType
     id: number

--- a/tests/composables/useApi.spec.ts
+++ b/tests/composables/useApi.spec.ts
@@ -59,7 +59,7 @@ describe('useApi', () => {
 
   describe('fetchData', () => {
     it('sets loading to true during fetch and false after', async () => {
-      const mockResponse = createApiResponse([], {})
+      const mockResponse = createApiResponse([], [])
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
         ok: true,
@@ -108,7 +108,7 @@ describe('useApi', () => {
     it('resets error before each fetch', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(createApiResponse([], {})),
+        json: () => Promise.resolve(createApiResponse([], [])),
       }))
 
       const { useApiConfig } = await import('@/composables/useApi')
@@ -124,7 +124,7 @@ describe('useApi', () => {
     it('filters out undefined and empty params from the URL', async () => {
       const fetchSpy = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(createApiResponse([], {})),
+        json: () => Promise.resolve(createApiResponse([], [])),
       })
       vi.stubGlobal('fetch', fetchSpy)
 
@@ -146,9 +146,9 @@ describe('useApi', () => {
 
   describe('transformFeatures', () => {
     it('sets is_before flag when feature ID matches link.before', async () => {
-      const feature1 = createFeature({ id: 10, properties: { links: 1 } as any })
-      const feature2 = createFeature({ id: 20, properties: { links: 1 } as any })
-      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const feature1 = createFeature({ id: 'bw10', properties: { links: 0 } })
+      const feature2 = createFeature({ id: 'aw20', properties: { links: 0 } })
+      const links = [[createLink({ before: 'bw10', after: 'aw20' })]]
       const mockData = createApiResponse([feature1, feature2], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -160,14 +160,14 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const beforeFeature = result?.features.find(f => f.id === 10)
+      const beforeFeature = result?.features.find(f => f.id === 'bw10')
       expect(beforeFeature?.properties.is_before).toBe(true)
     })
 
     it('sets is_after flag when feature ID matches link.after with before present', async () => {
-      const feature1 = createFeature({ id: 10, properties: { links: 1 } as any })
-      const feature2 = createFeature({ id: 20, properties: { links: 1 } as any })
-      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const feature1 = createFeature({ id: 'bw10', properties: { links: 0 } })
+      const feature2 = createFeature({ id: 'aw20', properties: { links: 0 } })
+      const links = [[createLink({ before: 'bw10', after: 'aw20' })]]
       const mockData = createApiResponse([feature1, feature2], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -179,14 +179,14 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const afterFeature = result?.features.find(f => f.id === 20)
+      const afterFeature = result?.features.find(f => f.id === 'aw20')
       expect(afterFeature?.properties.is_after).toBe(true)
     })
 
     it('sets is_after flag when link.before is undefined but link.after is defined', async () => {
-      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      const feature = createFeature({ id: 'aw10', properties: { links: 0 } })
       // Link has 'before' key but set to undefined, and 'after' set to feature id
-      const links = { 1: [createLink({ before: undefined, after: 10 })] }
+      const links = [[createLink({ before: undefined, after: 'aw10' })]]
       const mockData = createApiResponse([feature], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -198,15 +198,15 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const afterFeature = result?.features.find(f => f.id === 10)
+      const afterFeature = result?.features.find(f => f.id === 'aw10')
       expect(afterFeature?.properties.is_after).toBe(true)
     })
 
     it('sets is_new flag when link has no before key', async () => {
-      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
+      const feature = createFeature({ id: 'aw10', properties: { links: 0 } })
       // The 'before' key must not exist at all (not just undefined) for is_new to trigger
-      const link = { action: 'accept' as const, after: 10, diff_attribs: undefined, diff_tags: undefined, conflation_reason: { geom: { score: 0.9, reason: 'test' }, tags: { score: 0.8, reason: 'test' }, conflate: 'test' } }
-      const links = { 1: [link] }
+      const link = { action: 'accept' as const, after: 'aw10', diff_attribs: undefined, diff_tags: undefined, conflation_reason: { geom: { score: 0.9, reason: 'test' }, tags: { score: 0.8, reason: 'test' }, conflate: 'test' } }
+      const links = [[link]]
       const mockData = createApiResponse([feature], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -218,22 +218,22 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const newFeature = result?.features.find(f => f.id === 10)
+      const newFeature = result?.features.find(f => f.id === 'aw10')
       expect(newFeature?.properties.is_new).toBe(true)
     })
 
     it('sets geom to true when linked features have different geometries', async () => {
       const feature1 = createFeature({
-        id: 10,
+        id: 'bw10',
         geometry: { type: 'Point', coordinates: [2.35, 48.85] },
-        properties: { links: 1 } as any,
+        properties: { links: 0 },
       })
       const feature2 = createFeature({
-        id: 20,
+        id: 'aw20',
         geometry: { type: 'Point', coordinates: [3.00, 49.00] },
-        properties: { links: 1 } as any,
+        properties: { links: 0 },
       })
-      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const links = [[createLink({ before: 'bw10', after: 'aw20' })]]
       const mockData = createApiResponse([feature1, feature2], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -245,23 +245,23 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const beforeFeature = result?.features.find(f => f.id === 10)
+      const beforeFeature = result?.features.find(f => f.id === 'bw10')
       expect(beforeFeature?.properties.geom).toBe(true)
     })
 
     it('sets geom to false when linked features have identical geometries', async () => {
       const sharedGeometry = { type: 'Point' as const, coordinates: [2.35, 48.85] }
       const feature1 = createFeature({
-        id: 10,
+        id: 'bw10',
         geometry: sharedGeometry,
-        properties: { links: 1 } as any,
+        properties: { links: 0 },
       })
       const feature2 = createFeature({
-        id: 20,
+        id: 'aw20',
         geometry: sharedGeometry,
-        properties: { links: 1 } as any,
+        properties: { links: 0 },
       })
-      const links = { 1: [createLink({ before: 10, after: 20 })] }
+      const links = [[createLink({ before: 'bw10', after: 'aw20' })]]
       const mockData = createApiResponse([feature1, feature2], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -273,13 +273,13 @@ describe('useApi', () => {
       const { fetchData } = useApiConfig()
 
       const result = await fetchData({ date_start: '2024-01-01' })
-      const beforeFeature = result?.features.find(f => f.id === 10)
+      const beforeFeature = result?.features.find(f => f.id === 'bw10')
       expect(beforeFeature?.properties.geom).toBe(false)
     })
 
     it('throws error when feature has no matching group', async () => {
-      const feature = createFeature({ id: 10, properties: { links: 999 } as any })
-      const links = { 1: [createLink({ before: 10 })] }
+      const feature = createFeature({ id: 'bw10', properties: { links: 999 } })
+      const links = [[createLink({ before: 'bw10' })]]
       const mockData = createApiResponse([feature], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -296,8 +296,8 @@ describe('useApi', () => {
     })
 
     it('throws error when feature has no matching link', async () => {
-      const feature = createFeature({ id: 10, properties: { links: 1 } as any })
-      const links = { 1: [createLink({ before: 999, after: 888 })] }
+      const feature = createFeature({ id: 'bw10', properties: { links: 0 } })
+      const links = [[createLink({ before: 'bw999', after: 'aw888' })]]
       const mockData = createApiResponse([feature], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -315,25 +315,25 @@ describe('useApi', () => {
 
     it('sorts features by area in descending order', async () => {
       const smallPolygon = createFeature({
-        id: 10,
+        id: 'aw10',
         geometry: {
           type: 'Polygon',
           coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
         },
-        properties: { links: 1 } as any,
+        properties: { links: 0 },
       })
       const largePolygon = createFeature({
-        id: 20,
+        id: 'aw20',
         geometry: {
           type: 'Polygon',
           coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
         },
-        properties: { links: 2 } as any,
+        properties: { links: 1 },
       })
-      const links = {
-        1: [createLink({ after: 10 })],
-        2: [createLink({ after: 20 })],
-      }
+      const links = [
+        [createLink({ after: 'aw10' })],
+        [createLink({ after: 'aw20' })],
+      ]
       const mockData = createApiResponse([smallPolygon, largePolygon], links)
 
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -346,8 +346,8 @@ describe('useApi', () => {
 
       const result = await fetchData({ date_start: '2024-01-01' })
       // Large polygon (5 coords = area 500) should come before small (4 coords = area 400)
-      expect(result?.features[0].id).toBe(20)
-      expect(result?.features[1].id).toBe(10)
+      expect(result?.features[0].id).toBe('aw20')
+      expect(result?.features[1].id).toBe('aw10')
     })
   })
 })

--- a/tests/composables/useLoCha.spec.ts
+++ b/tests/composables/useLoCha.spec.ts
@@ -14,8 +14,8 @@ describe('useLoCha', () => {
     it('returns "new" for features with is_new flag', () => {
       const { getStatus } = useLoCha()
       const feature = createFeature({
-        id: 1,
-        properties: { is_new: true } as any,
+        id: 'n1',
+        properties: { is_new: true },
       })
       expect(getStatus(feature)).toBe('new')
     })
@@ -23,8 +23,8 @@ describe('useLoCha', () => {
     it('returns "delete" for deleted features', () => {
       const { getStatus } = useLoCha()
       const feature = createFeature({
-        id: 1,
-        properties: { deleted: true } as any,
+        id: 'n1',
+        properties: { deleted: true },
       })
       expect(getStatus(feature)).toBe('delete')
     })
@@ -32,23 +32,23 @@ describe('useLoCha', () => {
     it('returns "updateBefore" for is_before features', () => {
       const { getStatus } = useLoCha()
       const feature = createFeature({
-        id: 1,
-        properties: { is_before: true } as any,
+        id: 'n1',
+        properties: { is_before: true },
       })
       expect(getStatus(feature)).toBe('updateBefore')
     })
 
     it('returns "updateAfter" as the default status', () => {
       const { getStatus } = useLoCha()
-      const feature = createFeature({ id: 1 })
+      const feature = createFeature({ id: 'n1' })
       expect(getStatus(feature)).toBe('updateAfter')
     })
 
     it('prioritizes is_new over other flags', () => {
       const { getStatus } = useLoCha()
       const feature = createFeature({
-        id: 1,
-        properties: { is_new: true, is_before: true } as any,
+        id: 'n1',
+        properties: { is_new: true, is_before: true },
       })
       expect(getStatus(feature)).toBe('new')
     })
@@ -56,8 +56,8 @@ describe('useLoCha', () => {
     it('prioritizes deleted over is_before', () => {
       const { getStatus } = useLoCha()
       const feature = createFeature({
-        id: 1,
-        properties: { deleted: true, is_before: true } as any,
+        id: 'n1',
+        properties: { deleted: true, is_before: true },
       })
       expect(getStatus(feature)).toBe('delete')
     })
@@ -67,11 +67,11 @@ describe('useLoCha', () => {
     it('sets loCha data and populates groups', () => {
       const { setLoCha, loCha, groups } = useLoCha()
 
-      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
-      const feature2 = createFeature({ id: 2, properties: { links: 1 } as any })
+      const feature1 = createFeature({ id: 'n1', properties: { links: 0 } })
+      const feature2 = createFeature({ id: 'n2', properties: { links: 0 } })
       const data = createApiResponse(
         [feature1, feature2],
-        { 1: [createLink({ before: 1, after: 2 })] },
+        [[createLink({ before: 'n1', after: 'n2' })]],
       )
 
       setLoCha(data)
@@ -84,15 +84,15 @@ describe('useLoCha', () => {
     it('groups features by link ID', () => {
       const { setLoCha, groups } = useLoCha()
 
-      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
-      const feature2 = createFeature({ id: 2, properties: { links: 1 } as any })
-      const feature3 = createFeature({ id: 3, properties: { links: 2 } as any })
+      const feature1 = createFeature({ id: 'n1', properties: { links: 0 } })
+      const feature2 = createFeature({ id: 'n2', properties: { links: 0 } })
+      const feature3 = createFeature({ id: 'n3', properties: { links: 1 } })
       const data = createApiResponse(
         [feature1, feature2, feature3],
-        {
-          1: [createLink({ before: 1, after: 2 })],
-          2: [createLink({ after: 3 })],
-        },
+        [
+          [createLink({ before: 'n1', after: 'n2' })],
+          [createLink({ after: 'n3' })],
+        ],
       )
 
       setLoCha(data)
@@ -105,19 +105,19 @@ describe('useLoCha', () => {
     it('resets state before setting new data', () => {
       const { setLoCha, loCha } = useLoCha()
 
-      const feature1 = createFeature({ id: 1, properties: { links: 1 } as any })
+      const feature1 = createFeature({ id: 'n1', properties: { links: 0 } })
       const data1 = createApiResponse(
         [feature1],
-        { 1: [createLink({ after: 1 })] },
+        [[createLink({ after: 'n1' })]],
       )
       setLoCha(data1)
       expect(loCha.value?.features).toHaveLength(1)
 
-      const feature2 = createFeature({ id: 2, properties: { links: 2 } as any })
-      const feature3 = createFeature({ id: 3, properties: { links: 2 } as any })
+      const feature2 = createFeature({ id: 'n2', properties: { links: 0 } })
+      const feature3 = createFeature({ id: 'n3', properties: { links: 0 } })
       const data2 = createApiResponse(
         [feature2, feature3],
-        { 2: [createLink({ before: 2, after: 3 })] },
+        [[createLink({ before: 'n2', after: 'n3' })]],
       )
       setLoCha(data2)
       expect(loCha.value?.features).toHaveLength(2)
@@ -134,14 +134,14 @@ describe('useLoCha', () => {
       const { featureCount, setLoCha } = useLoCha()
 
       const features = [
-        createFeature({ id: 1, properties: { links: 1 } as any }),
-        createFeature({ id: 2, properties: { links: 1 } as any }),
-        createFeature({ id: 3, properties: { links: 2 } as any }),
+        createFeature({ id: 'n1', properties: { links: 0 } }),
+        createFeature({ id: 'n2', properties: { links: 0 } }),
+        createFeature({ id: 'n3', properties: { links: 1 } }),
       ]
-      const data = createApiResponse(features, {
-        1: [createLink({ before: 1, after: 2 })],
-        2: [createLink({ after: 3 })],
-      })
+      const data = createApiResponse(features, [
+        [createLink({ before: 'n1', after: 'n2' })],
+        [createLink({ after: 'n3' })],
+      ])
 
       setLoCha(data)
       expect(featureCount.value).toBe(3)

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -1,19 +1,24 @@
 import type { ActionType, ApiLink, ApiLinkGroups, ApiResponse, IFeature } from '@/types'
 
-export function createFeature(overrides: Partial<IFeature> & { id: number }): IFeature {
-  const { properties: propOverrides, ...rest } = overrides
+const NON_DIGIT_RE = /\D/g
 
+interface CreateFeatureOptions {
+  id: string
+  geometry?: GeoJSON.Geometry
+  properties?: Partial<IFeature['properties']>
+}
+
+export function createFeature(options: CreateFeatureOptions): IFeature {
   return {
     type: 'Feature',
-    geometry: {
+    geometry: options.geometry ?? {
       type: 'Point',
       coordinates: [2.35, 48.85],
     },
-    id: overrides.id,
-    ...rest,
+    id: options.id,
     properties: {
       objtype: 'node',
-      id: overrides.id,
+      id: Number.parseInt(options.id.replace(NON_DIGIT_RE, '')) || 0,
       geom_distance: null,
       geom: false,
       deleted: false,
@@ -23,9 +28,9 @@ export function createFeature(overrides: Partial<IFeature> & { id: number }): IF
       username: 'testuser',
       created: '2024-01-01T00:00:00Z',
       tags: { name: 'Test' },
-      ...propOverrides,
+      ...options.properties,
     },
-  } as IFeature
+  }
 }
 
 export function createLink(overrides: Partial<ApiLink> = {}): ApiLink {
@@ -46,7 +51,7 @@ export function createLink(overrides: Partial<ApiLink> = {}): ApiLink {
 
 export function createApiResponse(
   features: IFeature[],
-  links: ApiLinkGroups = {},
+  links: ApiLinkGroups = [],
 ): ApiResponse {
   return {
     type: 'FeatureCollection',


### PR DESCRIPTION
## Summary
- Change `ApiLinkGroups` from `Record<number, ApiLink[]>` to `ApiLink[][]`
- Change `IFeature.id` from `number` to `string`
- Change `ApiLink.before`/`ApiLink.after` from `number` to `string`
- Update all test factories and test assertions to match the new types

## Test plan
- [x] All 36 existing tests pass
- [x] Lint passes
- [x] Library builds successfully (ESM + UMD + types)

Closes #57