### PR TITLE
feat: adapt ObjectType to short codes from Clearance API

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -38,7 +38,7 @@ function getTagsTitle(link: ApiLink): string {
   const beforeFeature = loCha.value!.features.find(feature => feature.id === link!.before)
 
   if (beforeFeature)
-    title = `${beforeFeature.properties.objtype[0]}${beforeFeature.properties.id}-v${beforeFeature.properties.version}`
+    title = `${beforeFeature.properties.objtype}${beforeFeature.properties.id}-v${beforeFeature.properties.version}`
 
   return title
 }

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -38,7 +38,7 @@ const color = computed(() => loChaColors[status.value])
           target="_blank"
           @click.stop
         >
-          {{ `${feature.properties.objtype[0]}${feature.properties.id}-v${feature.properties.version}` }}
+          {{ `${feature.properties.objtype}${feature.properties.id}-v${feature.properties.version}` }}
         </a>
         <div
           v-if="status === 'new' || status === 'delete'"

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,6 +10,7 @@ import { shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
 import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
+import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
 const props = defineProps<{
@@ -208,7 +209,7 @@ function openPopup(coords: LngLatLike, feature: maplibre.MapGeoJSONFeature): voi
 
   popup.value = new maplibre.Popup()
     .setLngLat(coords)
-    .setHTML(`${feature.properties.objtype}-${feature.properties.id}-v${feature.properties.version}`)
+    .setHTML(`${OBJTYPE_FULL[feature.properties.objtype as keyof typeof OBJTYPE_FULL]}-${feature.properties.id}-v${feature.properties.version}`)
     .addTo(map.value)
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,4 @@
-export type ObjectType = 'node' | 'way' | 'relation'
+export type ObjectType = 'n' | 'w' | 'r'
 
 export type ActionType = 'accept' | 'reject'
 

--- a/src/utils/osm-links.ts
+++ b/src/utils/osm-links.ts
@@ -1,19 +1,27 @@
-export function getOsmHistoryUrl(objtype: string, id: number): string {
-  return `https://www.openstreetmap.org/${objtype}/${id}/history`
+import type { ObjectType } from '@/types'
+
+export const OBJTYPE_FULL: Record<ObjectType, string> = {
+  n: 'node',
+  w: 'way',
+  r: 'relation',
+}
+
+export function getOsmHistoryUrl(objtype: ObjectType, id: number): string {
+  return `https://www.openstreetmap.org/${OBJTYPE_FULL[objtype]}/${id}/history`
 }
 
 export function getOsmUserUrl(username: string): string {
   return `https://www.openstreetmap.org/user/${encodeURIComponent(username)}`
 }
 
-export function getJosmUrl(objtype: string, id: number): string {
-  return `http://127.0.0.1:8111/load_object?objects=${objtype[0]}${id}`
+export function getJosmUrl(objtype: ObjectType, id: number): string {
+  return `http://127.0.0.1:8111/load_object?objects=${objtype}${id}`
 }
 
-export function getDeepHistoryUrl(objtype: string, id: number): string {
-  return `https://osmlab.github.io/osm-deep-history/#/${objtype}/${id}`
+export function getDeepHistoryUrl(objtype: ObjectType, id: number): string {
+  return `https://osmlab.github.io/osm-deep-history/#/${OBJTYPE_FULL[objtype]}/${id}`
 }
 
-export function getOsmHistoryViewerUrl(objtype: string, id: number): string {
-  return `https://pewu.github.io/osm-history/#/${objtype}/${id}`
+export function getOsmHistoryViewerUrl(objtype: ObjectType, id: number): string {
+  return `https://pewu.github.io/osm-history/#/${OBJTYPE_FULL[objtype]}/${id}`
 }

--- a/tests/factories/index.ts
+++ b/tests/factories/index.ts
@@ -17,7 +17,7 @@ export function createFeature(options: CreateFeatureOptions): IFeature {
     },
     id: options.id,
     properties: {
-      objtype: 'node',
+      objtype: 'n',
       id: Number.parseInt(options.id.replace(NON_DIGIT_RE, '')) || 0,
       geom_distance: null,
       geom: false,


### PR DESCRIPTION
## Summary
- Change `ObjectType` from `'node' | 'way' | 'relation'` to `'n' | 'w' | 'r'`
- Add `OBJTYPE_FULL` mapping in `osm-links.ts` for URLs that require full names
- Simplify display labels that used `objtype[0]` (now redundant)
- Update test factory default `objtype` to `'n'`

Ref: https://github.com/teritorio/clearance/issues/31

## Test plan
- [x] All 36 tests pass
- [x] Lint clean
- [x] Build succeeds

Closes #59