### PR TITLE
fix: handle degenerate bbox for single-point features

### DIFF
--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -46,6 +46,9 @@ export function clipAndEnvelope(
   return turfEnvelope(fc)
 }
 
+// ~100m padding in degrees, used to expand degenerate (zero-area) bboxes
+const BBOX_PADDING = 0.001
+
 export function normalizeBbox(
   bbox: GeoJSON.BBox,
 ): [number, number, number, number] {
@@ -57,6 +60,15 @@ export function normalizeBbox(
   if (Math.abs(minX) <= 90 && Math.abs(maxX) <= 90) {
     [minX, minY] = [minY, minX];
     [maxX, maxY] = [maxY, maxX]
+  }
+
+  if (minX === maxX) {
+    minX -= BBOX_PADDING
+    maxX += BBOX_PADDING
+  }
+  if (minY === maxY) {
+    minY -= BBOX_PADDING
+    maxY += BBOX_PADDING
   }
 
   return [minX, minY, maxX, maxY]

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeBbox } from '@/utils/geom'
+
+describe('normalizeBbox', () => {
+  it('returns bbox unchanged when non-degenerate and no swap needed', () => {
+    // minX and maxX outside [-90, 90] → no swap
+    const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
+    expect(normalizeBbox(bbox)).toEqual([-122.5, 37.7, -122.4, 37.8])
+  })
+
+  it('swaps lat/lng when values suggest reversed order', () => {
+    // Both minX and maxX within [-90, 90] triggers the swap
+    // Input: [lat_min, lng_min, lat_max, lng_max] → Output: [lng_min, lat_min, lng_max, lat_max]
+    const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
+    expect(normalizeBbox(bbox)).toEqual([-1.6, 43.4, -1.5, 43.5])
+  })
+
+  it('pads degenerate bbox where minX === maxX', () => {
+    const bbox = [-122.5, 37.7, -122.5, 37.8] as [number, number, number, number]
+    const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
+    expect(result[2]).toBeGreaterThan(-122.5)
+    expect(result[1]).toBe(37.7)
+    expect(result[3]).toBe(37.8)
+  })
+
+  it('pads degenerate bbox where minY === maxY', () => {
+    const bbox = [-122.5, 37.7, -122.4, 37.7] as [number, number, number, number]
+    const result = normalizeBbox(bbox)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[3]).toBeGreaterThan(37.7)
+    expect(result[0]).toBe(-122.5)
+    expect(result[2]).toBe(-122.4)
+  })
+
+  it('pads fully degenerate bbox (single point) after swap', () => {
+    // API returns [lat, lng, lat, lng] → swap → [lng, lat, lng, lat] → pad both axes
+    const bbox = [43.457, -1.572, 43.457, -1.572] as [number, number, number, number]
+    const result = normalizeBbox(bbox)
+    // After swap: [-1.572, 43.457, -1.572, 43.457] → both axes padded
+    expect(result[0]).toBeLessThan(-1.572)
+    expect(result[2]).toBeGreaterThan(-1.572)
+    expect(result[1]).toBeLessThan(43.457)
+    expect(result[3]).toBeGreaterThan(43.457)
+  })
+})


### PR DESCRIPTION
## Summary
- Add padding (~100m) in `normalizeBbox()` when min === max on either axis
- Prevents `turfBooleanContains` from failing on zero-area bbox polygons
- New test file `tests/utils/geom.spec.ts` with 5 tests covering normal, swapped, and degenerate bboxes

Ref: https://github.com/teritorio/clearance/issues/28 (won't fix API-side)

## Test plan
- [x] All 41 tests pass
- [x] Lint clean

Closes #61