### PR TITLE
fix(deps): patch picomatch and yaml security vulnerabilities

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6262,9 +6262,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -7678,11 +7678,11 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.0.0, yaml@npm:^2.8.2":
-  version: 2.8.2
-  resolution: "yaml@npm:2.8.2"
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `picomatch` 4.0.3 → 4.0.4 — fixes ReDoS via extglob quantifiers (high) and method injection in POSIX character classes (medium)
- Upgrade `yaml` 2.8.2 → 2.8.3 — fixes stack overflow via deeply nested YAML collections (medium)

## Test plan
- [x] `yarn test` — 84/84 tests pass
- [x] `yarn build` — library builds successfully
- [x] `yarn why picomatch` confirms 4.0.4
- [x] `yarn why yaml` confirms 2.8.3

Closes #67