### PR TITLE
fix: add immediate option to data watcher in LoCha component

### DIFF
--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -25,7 +25,7 @@ watch(() => props.data, (newValue) => {
   if (newValue) {
     setLoCha(newValue)
   }
-})
+}, { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Add `{ immediate: true }` to the `watch` on `props.data` in `LoCha.vue`
- Without this, when `<LoCha>` is mounted with data already set via props, the watch callback never fires because the value doesn't change — resulting in "No data" being displayed

## Context
Discovered while integrating LoCha into [clearance-frontend#293](https://github.com/teritorio/clearance-frontend/issues/293). The component is rendered inside a `v-for` loop where data is immediately available.

## Test plan
- Mount `<LoCha :data="someApiResponse">` where `someApiResponse` is already defined — should render data instead of "No data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)