### PR TITLE
fix: restrict Sentry plugin to demo and dev builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,17 +17,6 @@ export default defineConfig(({ command, mode }) => {
     },
     plugins: [
       vue(),
-      sentryVitePlugin({
-        authToken: env.VITE_SENTRY_AUTH_TOKEN,
-        sourcemaps: {
-          filesToDeleteAfterUpload: [
-            './**/*.map',
-            '.*/**/public/**/*.map',
-            './dist/**/client/**/*.map',
-          ],
-        },
-        telemetry: false,
-      }),
     ],
   } satisfies UserConfig
 
@@ -40,6 +29,13 @@ export default defineConfig(({ command, mode }) => {
         sourcemap: true,
       },
       ...baseConfig,
+      plugins: [
+        ...baseConfig.plugins,
+        sentryVitePlugin({
+          authToken: env.VITE_SENTRY_AUTH_TOKEN,
+          telemetry: false,
+        }),
+      ],
     }
   }
 
@@ -80,6 +76,13 @@ export default defineConfig(({ command, mode }) => {
     build: {
       sourcemap: true,
     },
+    plugins: [
+      ...baseConfig.plugins,
+      sentryVitePlugin({
+        authToken: env.VITE_SENTRY_AUTH_TOKEN,
+        telemetry: false,
+      }),
+    ],
     server: {
       proxy: {
         '/api': {


### PR DESCRIPTION
## Summary
- Move Sentry Vite plugin out of `baseConfig` so it only applies to demo and dev builds
- Remove `filesToDeleteAfterUpload` which was deleting sourcemaps from `dist/` even without a Sentry auth token
- Library consumers have their own Sentry setup — the plugin in lib build was only causing issues (missing sourcemaps, unnecessary warnings)

## Context
Discovered while integrating LoCha into [clearance-frontend#293](https://github.com/teritorio/clearance-frontend/issues/293). Vite was logging sourcemap load errors because `dist/index.js.map` was deleted after build.

## Test plan
- `yarn build` → verify `dist/index.js.map` and `dist/index.umd.cjs.map` exist
- `yarn build:demo` → verify Sentry plugin still runs for demo deployment
- No Sentry warnings during lib build

🤖 Generated with [Claude Code](https://claude.com/claude-code)