### PR TITLE
fix: remove vue-router dependency from exported components

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "@turf/helpers": "^7.3.4",
     "@vueuse/components": "^14.2.1",
     "diff": "^8.0.3",
-    "underscore": "^1.13.8",
-    "vue-router": "^5.0.3"
+    "underscore": "^1.13.8"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.7.3",
@@ -80,6 +79,7 @@
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^4.1.0",
     "vue": "^3.5.30",
+    "vue-router": "^5.0.3",
     "vue-tsc": "^3.2.6"
   },
   "resolutions": {

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -8,6 +8,9 @@ import { REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 const props = withDefaults(defineProps<{
   data?: ApiResponse
   reasonCollapsed?: boolean
+  hash?: string
+  dateStart?: string
+  dateEnd?: string
 }>(), {
   reasonCollapsed: true,
 })
@@ -33,7 +36,7 @@ watch(() => props.data, (newValue) => {
     <p v-if="!featureCount" class="user-feedback">
       ⚠️ No data
     </p>
-    <LoChaGroupList v-else>
+    <LoChaGroupList v-else :hash="hash" :date-start="dateStart" :date-end="dateEnd">
       <template #tags-diff="slotProps">
         <slot name="tags-diff" v-bind="slotProps" />
       </template>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,19 +1,23 @@
 <script setup lang="ts">
 import type { TagsDiffSlotProps } from '@/types'
 import { computed, nextTick, ref, watch } from 'vue'
-import { useRoute } from 'vue-router'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors, useLoCha } from '@/composables/useLoCha'
 import { formatDate } from '@/utils/date-format'
+
+const props = defineProps<{
+  hash?: string
+  dateStart?: string
+  dateEnd?: string
+}>()
 
 defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
 
 const { groups } = useLoCha()
 const highlightBorderColor = loChaColors.delete
-const route = useRoute()
 const currentHash = ref<string>()
 
-watch(() => route.hash, (newValue) => {
+watch(() => props.hash, (newValue) => {
   currentHash.value = newValue
   if (newValue) {
     nextTick(() => scrollToSection(newValue))
@@ -23,15 +27,15 @@ watch(() => route.hash, (newValue) => {
 })
 
 const dateFrom = computed(() => {
-  if (route.query.date_start) {
-    return formatDate(route.query.date_start.toString())
+  if (props.dateStart) {
+    return formatDate(props.dateStart)
   }
 
   return undefined
 })
 const dateTo = computed(() => {
-  if (route.query.date_end) {
-    return formatDate(route.query.date_end.toString())
+  if (props.dateEnd) {
+    return formatDate(props.dateEnd)
   }
 
   return undefined


### PR DESCRIPTION
## Summary
- Replace `useRoute()` in `LoChaGroupList.vue` with props (`hash`, `dateStart`, `dateEnd`) passed down from `<LoCha>`
- Move `vue-router` from `dependencies` to `devDependencies` (only needed for demo app)
- No vue-router references remain in the built library output

## Why
The `<LoCha>` component should be plug-and-play. Using `useRoute()` internally causes `Symbol(route location) not found` errors in consumer projects (e.g., Nuxt apps with portal/symlink dependencies) due to duplicate vue-router instances.

## New props on `<LoCha>`
| Prop | Type | Description |
|---|---|---|
| `hash` | `string?` | Current URL hash for scroll-to-anchor and group highlighting |
| `dateStart` | `string?` | Start date to display in header |
| `dateEnd` | `string?` | End date to display in header |

## Test plan
- Use `<LoCha :data="..." />` in a Nuxt app without passing router props → no injection error
- Pass `hash="#group-0"` → group 0 is highlighted and scrolled to
- Pass `date-start` / `date-end` → dates render in header

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)