### PR TITLE
fix: make geom and tags optional in Reason type

### DIFF
--- a/src/components/LoCha/LoChaReason.vue
+++ b/src/components/LoCha/LoChaReason.vue
@@ -7,9 +7,9 @@ const props = defineProps<{
   reason: Reason
 }>()
 
-const nonEmptyEntries = computed(() => Object.entries(props.reason).filter(([_key, values]) => !!values) as Array<[keyof Reason, Reason[keyof Reason]]>)
+const nonEmptyEntries = computed(() => Object.entries(props.reason).filter(([_key, values]) => !!values) as Array<[keyof Reason, NonNullable<Reason[keyof Reason]>]>)
 
-function isObject(entry?: Reason[keyof Reason]): boolean {
+function isObject(entry?: NonNullable<Reason[keyof Reason]>): boolean {
   return !!entry && typeof entry === 'object' && !Array.isArray(entry)
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -21,8 +21,8 @@ export interface ReasonTags {
 }
 
 export interface Reason {
-  geom: ReasonGeom
-  tags: ReasonTags
+  geom?: ReasonGeom
+  tags?: ReasonTags
   conflate: string
 }
 

--- a/tests/utils/feature-transform.spec.ts
+++ b/tests/utils/feature-transform.spec.ts
@@ -46,6 +46,16 @@ describe('transformFeatures', () => {
     expect(result[0].properties.is_new).toBe(true)
   })
 
+  it('handles partial conflation_reason without geom and tags', async () => {
+    const transformFeatures = await importTransform()
+    const f1 = createFeature({ id: 'n1', properties: { links: 0 } })
+    const f2 = createFeature({ id: 'n2', properties: { links: 0 } })
+    const data = createApiResponse([f1, f2], [[createLink({ before: 'n1', after: 'n2', conflation_reason: { conflate: 'remeaning only after object' } })]])
+
+    const result = transformFeatures(data)
+    expect(result).toHaveLength(2)
+  })
+
   it('sets is_after when link.before is undefined but link.after is defined', async () => {
     const transformFeatures = await importTransform()
     const f1 = createFeature({ id: 'n1', properties: { links: 0 } })


### PR DESCRIPTION
## Summary

- Make `geom` and `tags` optional in the `Reason` interface to match API behavior (these fields are absent when there is no conflation)
- Fix TypeScript errors in `LoChaReason` component by using `NonNullable` type wrapper
- Add test for partial `conflation_reason` (without `geom`/`tags`)

Fixes #75
Relates to https://github.com/teritorio/clearance/issues/32

## Test plan

- [x] TypeScript compiles without errors
- [x] All 85 tests pass
- [x] New test verifies `transformFeatures` handles partial `conflation_reason`