### PR TITLE
fix: standardize bbox to GeoJSON format

### DIFF
--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -109,18 +109,10 @@ export function useApiConfig(): ApiComposable {
 
         return await res.json() as ApiResponse
       })
-      .then((data) => {
-        // Temporary: normalize API bbox from [south,west,north,east] to GeoJSON [west,south,east,north]
-        // Remove once teritorio/clearance#33 is resolved
-        if (data.bbox && data.bbox.length >= 4) {
-          data.bbox = [data.bbox[1], data.bbox[0], data.bbox[3], data.bbox[2]]
-        }
-
-        return {
-          ...data,
-          features: transformFeatures(data),
-        }
-      })
+      .then(data => ({
+        ...data,
+        features: transformFeatures(data),
+      }))
       .catch((err) => {
         setError({
           message: err.message,

--- a/src/composables/useApi.ts
+++ b/src/composables/useApi.ts
@@ -109,10 +109,18 @@ export function useApiConfig(): ApiComposable {
 
         return await res.json() as ApiResponse
       })
-      .then(data => ({
-        ...data,
-        features: transformFeatures(data),
-      }))
+      .then((data) => {
+        // Temporary: normalize API bbox from [south,west,north,east] to GeoJSON [west,south,east,north]
+        // Remove once teritorio/clearance#33 is resolved
+        if (data.bbox && data.bbox.length >= 4) {
+          data.bbox = [data.bbox[1], data.bbox[0], data.bbox[3], data.bbox[2]]
+        }
+
+        return {
+          ...data,
+          features: transformFeatures(data),
+        }
+      })
       .catch((err) => {
         setError({
           message: err.message,

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -57,11 +57,6 @@ export function normalizeBbox(
   let maxX = bbox[2]
   let maxY = bbox[3]
 
-  if (Math.abs(minX) <= 90 && Math.abs(maxX) <= 90) {
-    [minX, minY] = [minY, minX];
-    [maxX, maxY] = [maxY, maxX]
-  }
-
   if (minX === maxX) {
     minX -= BBOX_PADDING
     maxX += BBOX_PADDING

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -103,11 +103,9 @@ describe('normalizeBbox', () => {
     expect(normalizeBbox(bbox)).toEqual([-122.5, 37.7, -122.4, 37.8])
   })
 
-  it('swaps lat/lng when values suggest reversed order', () => {
-    // Both minX and maxX within [-90, 90] triggers the swap
-    // Input: [lat_min, lng_min, lat_max, lng_max] → Output: [lng_min, lat_min, lng_max, lat_max]
+  it('returns bbox unchanged when already in standard GeoJSON format', () => {
     const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([-1.6, 43.4, -1.5, 43.5])
+    expect(normalizeBbox(bbox)).toEqual([43.4, -1.6, 43.5, -1.5])
   })
 
   it('pads degenerate bbox where minX === maxX', () => {
@@ -128,11 +126,9 @@ describe('normalizeBbox', () => {
     expect(result[2]).toBe(-122.4)
   })
 
-  it('pads fully degenerate bbox (single point) after swap', () => {
-    // API returns [lat, lng, lat, lng] → swap → [lng, lat, lng, lat] → pad both axes
-    const bbox = [43.457, -1.572, 43.457, -1.572] as [number, number, number, number]
+  it('pads fully degenerate bbox (single point)', () => {
+    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
     const result = normalizeBbox(bbox)
-    // After swap: [-1.572, 43.457, -1.572, 43.457] → both axes padded
     expect(result[0]).toBeLessThan(-1.572)
     expect(result[2]).toBeGreaterThan(-1.572)
     expect(result[1]).toBeLessThan(43.457)


### PR DESCRIPTION
## Summary
- Normalize API bbox from `[south, west, north, east]` to GeoJSON standard `[west, south, east, north]` at the API fetch boundary in `useApi.ts`
- Remove the fragile heuristic swap (`abs <= 90`) in `normalizeBbox()`, keeping only degenerate-bbox padding
- `displayBbox()` in `VMap.vue` now correctly renders the bbox rectangle (no change needed, already correct since 0e59ad0)

## Context
The API (`clearance`) returns bbox in `[south, west, north, east]` format. A temporary swap is applied at fetch time until teritorio/clearance#33 is resolved server-side.

## Test plan
- [ ] Verify bbox black dashed border is visible on the map
- [ ] Verify features are correctly clipped to the bbox area
- [ ] Test with different presets (Bayonne, Bordeaux, Pampelune, etc.)

Closes #78