### PR TITLE
fix: pass Before/After dates to LoCha component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -85,7 +85,7 @@ function handleSubmit(data: FormData) {
       :is-open="mapFiltersIsOpen"
       @submit="handleSubmit"
     />
-    <LoCha :data="geojson" :reason-collapsed="false">
+    <LoCha :data="geojson" :reason-collapsed="false" :date-start="route.query.date_start as string" :date-end="route.query.date_end as string">
       <template #tags-diff="{ title, date, diff, dst, src, reason }">
         <div class="infos">
           <span v-if="title" class="title">🔗 {{ title }}</span>


### PR DESCRIPTION
## Summary
- Pass `dateStart` and `dateEnd` props from `App.vue` to `<LoCha>`, sourced from route query parameters
- Fixes the "Before" / "After" date headers being empty in `LoChaGroupList`

Closes #85

## Test plan
- [ ] Load the demo app with `date_start` and `date_end` query params
- [ ] Verify "Before" and "After" headers display the correct dates