### PR TITLE
feat: add link-metadata slot and move header to consumer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,7 @@ function handleSubmit(data: FormData) {
       :is-open="mapFiltersIsOpen"
       @submit="handleSubmit"
     />
-    <div class="locha-header">
+    <div v-if="dateFrom || dateTo" class="locha-header">
       <h2>Before : {{ dateFrom }}</h2>
       <h2>After : {{ dateTo }}</h2>
     </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@ import VError from '@/components/VError.vue'
 import VHeader from '@/components/VHeader.vue'
 import VLoading from '@/components/VLoading.vue'
 import { useApiConfig } from '@/composables/useApi'
-import { fromDatetimeLocal, toDatetimeLocal } from '@/utils/date-format'
+import { formatDate, fromDatetimeLocal, toDatetimeLocal } from '@/utils/date-format'
 
 const $api = useApiConfig()
 const { error, loading, resetError } = $api
@@ -20,6 +20,16 @@ const mapFiltersIsOpen = ref(true)
 
 const route = useRoute()
 const router = useRouter()
+
+const dateFrom = computed(() => {
+  const dateStart = route.query.date_start as string | undefined
+  return dateStart ? formatDate(dateStart) : undefined
+})
+
+const dateTo = computed(() => {
+  const dateEnd = route.query.date_end as string | undefined
+  return dateEnd ? formatDate(dateEnd) : undefined
+})
 
 const initialFormValues = computed<FormData>(() => ({
   dateStart: route.query.date_start ? toDatetimeLocal(String(route.query.date_start)) : '',
@@ -85,7 +95,11 @@ function handleSubmit(data: FormData) {
       :is-open="mapFiltersIsOpen"
       @submit="handleSubmit"
     />
-    <LoCha :data="geojson" :reason-collapsed="false" :date-start="route.query.date_start as string" :date-end="route.query.date_end as string">
+    <div class="locha-header">
+      <h2>Before : {{ dateFrom }}</h2>
+      <h2>After : {{ dateTo }}</h2>
+    </div>
+    <LoCha :data="geojson" :reason-collapsed="false">
       <template #tags-diff="{ title, date, diff, dst, src, reason }">
         <div class="infos">
           <span v-if="title" class="title">🔗 {{ title }}</span>
@@ -106,8 +120,20 @@ function handleSubmit(data: FormData) {
 <style lang="css" scoped>
 main {
   display: grid;
-  grid-template-rows: 1fr;
+  grid-template-rows: auto 1fr;
   height: calc(100vh - 64px);
   transition: grid-template-columns 0.3s ease;
+}
+
+.locha-header {
+  grid-column: 2;
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1rem 0;
+}
+
+.locha-header h2 {
+  flex: 1;
+  text-align: center;
 }
 </style>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiResponse, TagsDiffSlotProps } from '@/types'
+import type { ApiResponse, LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
 import { provide, useId, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -9,13 +9,14 @@ const props = withDefaults(defineProps<{
   data?: ApiResponse
   reasonCollapsed?: boolean
   hash?: string
-  dateStart?: string
-  dateEnd?: string
 }>(), {
   reasonCollapsed: true,
 })
 
-defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
+defineSlots<{
+  'tags-diff': (props: TagsDiffSlotProps) => void
+  'link-metadata': (props: LinkMetadataSlotProps) => void
+}>()
 
 const instanceId = useId()
 
@@ -42,9 +43,12 @@ watch(() => props.data, (newValue) => {
     <p v-if="!featureCount" class="user-feedback">
       ⚠️ No data
     </p>
-    <LoChaGroupList v-else :hash="hash" :date-start="dateStart" :date-end="dateEnd">
+    <LoChaGroupList v-else :hash="hash">
       <template #tags-diff="slotProps">
         <slot name="tags-diff" v-bind="slotProps" />
+      </template>
+      <template #link-metadata="slotProps">
+        <slot name="link-metadata" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -52,55 +52,57 @@ function getTagsTitle(link: ApiLink): string {
 </script>
 
 <template>
-  <div class="locha-group">
-    <div class="before-list">
-      <ul>
-        <li
-          v-for="feature in getBeforeFeatures(features)"
-          :key="feature.id"
-        >
-          <LoChaObject :feature="feature" :josm-target="josmTarget">
-            <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                <slot
-                  name="tags-diff"
-                  :date="feature.properties.created"
-                  :diff="link.diff_tags"
-                  :src="feature.properties"
-                  :reason="link.conflation_reason"
-                />
-              </template>
-            </template>
-          </LoChaObject>
-        </li>
-      </ul>
-    </div>
-    <div class="after-list">
-      <ul>
-        <li
-          v-for="feature in getAfterFeatures(features)"
-          :key="feature.id"
-        >
-          <LoChaObject :feature="feature" :josm-target="josmTarget">
-            <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                <slot
-                  name="tags-diff"
-                  :date="feature.properties.created"
-                  :title="getTagsTitle(link)"
-                  :diff="link.diff_tags"
-                  :reason="link.conflation_reason"
-                  :dst="feature.properties"
-                  :src="getBeforeProperties(link)"
-                />
-              </template>
-            </template>
-          </LoChaObject>
-        </li>
-      </ul>
-    </div>
+  <div>
     <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
-    <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />
+    <div class="locha-group">
+      <div class="before-list">
+        <ul>
+          <li
+            v-for="feature in getBeforeFeatures(features)"
+            :key="feature.id"
+          >
+            <LoChaObject :feature="feature" :josm-target="josmTarget">
+              <template #tags-diff>
+                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                  <slot
+                    name="tags-diff"
+                    :date="feature.properties.created"
+                    :diff="link.diff_tags"
+                    :src="feature.properties"
+                    :reason="link.conflation_reason"
+                  />
+                </template>
+              </template>
+            </LoChaObject>
+          </li>
+        </ul>
+      </div>
+      <div class="after-list">
+        <ul>
+          <li
+            v-for="feature in getAfterFeatures(features)"
+            :key="feature.id"
+          >
+            <LoChaObject :feature="feature" :josm-target="josmTarget">
+              <template #tags-diff>
+                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                  <slot
+                    name="tags-diff"
+                    :date="feature.properties.created"
+                    :title="getTagsTitle(link)"
+                    :diff="link.diff_tags"
+                    :reason="link.conflation_reason"
+                    :dst="feature.properties"
+                    :src="getBeforeProperties(link)"
+                  />
+                </template>
+              </template>
+            </LoChaObject>
+          </li>
+        </ul>
+      </div>
+      <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />
+    </div>
   </div>
 </template>
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature, LoChaGroup, TagsDiffSlotProps } from '@/types'
+import type { ApiLink, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
 import { inject } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
@@ -11,7 +11,10 @@ const props = defineProps<{
   josmTarget?: string
 }>()
 
-defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
+defineSlots<{
+  'tags-diff': (props: TagsDiffSlotProps) => void
+  'link-metadata': (props: LinkMetadataSlotProps) => void
+}>()
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -96,6 +99,7 @@ function getTagsTitle(link: ApiLink): string {
         </li>
       </ul>
     </div>
+    <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
     <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />
   </div>
 </template>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import type { TagsDiffSlotProps } from '@/types'
-import { computed, inject, nextTick, ref, useTemplateRef, watch } from 'vue'
+import type { LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
+import { inject, nextTick, ref, useTemplateRef, watch } from 'vue'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors } from '@/composables/useLoCha'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
-import { formatDate } from '@/utils/date-format'
 
 const props = defineProps<{
   hash?: string
-  dateStart?: string
-  dateEnd?: string
 }>()
 
-defineSlots<{ 'tags-diff': (props: TagsDiffSlotProps) => void }>()
+defineSlots<{
+  'tags-diff': (props: TagsDiffSlotProps) => void
+  'link-metadata': (props: LinkMetadataSlotProps) => void
+}>()
 
 const { groups } = inject(LOCHA_KEY)!
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
@@ -35,21 +35,6 @@ watch(() => props.hash, (newValue) => {
   }
 }, {
   immediate: true,
-})
-
-const dateFrom = computed(() => {
-  if (props.dateStart) {
-    return formatDate(props.dateStart)
-  }
-
-  return undefined
-})
-const dateTo = computed(() => {
-  if (props.dateEnd) {
-    return formatDate(props.dateEnd)
-  }
-
-  return undefined
 })
 
 function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {}): boolean {
@@ -79,16 +64,15 @@ function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {})
 
 <template>
   <div ref="listRef" class="locha-group-list">
-    <header>
-      <h2>Before : {{ dateFrom }}</h2>
-      <h2>After : {{ dateTo }}</h2>
-    </header>
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
         <a class="anchor-button" :href="`#${groupId(index)}`">🔗</a>
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />
+          </template>
+          <template #link-metadata="slotProps">
+            <slot name="link-metadata" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>
@@ -99,28 +83,13 @@ function scrollToSection(sectionId: string, options: ScrollIntoViewOptions = {})
 
 <style lang="css" scoped>
 .locha-group-list {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: auto 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   padding: 1rem;
 }
 
-.locha-group-list header {
-  grid-row: 1;
-  grid-column: 1 / 3;
-  display: flex;
-  gap: 1rem;
-}
-
-.locha-group-list header h2 {
-  flex: 50%;
-  text-align: center;
-}
-
 .locha-group-list > ul {
-  grid-row: 2;
-  grid-column: 1 / 4;
   overflow-y: auto;
   margin-right: -12px;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export type {
   ApiLinkGroups,
   ApiResponse,
   IFeature,
+  LinkMetadataSlotProps,
   Reason,
   ReasonGeom,
   ReasonTags,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { Actions, ApiResponse, IFeature, Reason } from './api'
+import type { Actions, ApiLink, ApiResponse, IFeature, Reason } from './api'
 
 /**
  * The possible statuses for features in the system.
@@ -38,6 +38,14 @@ export interface TagsDiffSlotProps {
   dst?: IFeature['properties']
   reason: Reason
   title?: string
+}
+
+/**
+ * Props passed through the `link-metadata` slot across the LoCha component hierarchy.
+ */
+export interface LinkMetadataSlotProps {
+  links: ApiLink[]
+  index: number
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add a `link-metadata` named slot on `<LoCha>` exposing `links: ApiLink[]` and `index: number` per group, allowing consumers to render custom metadata (matches, selectors, user groups) alongside the built-in diff and map views
- Remove `dateStart`/`dateEnd` props from `LoCha` and `LoChaGroupList` — the "Before/After" header is now the consumer's responsibility
- Move the header display to the demo `App.vue`
- Export new `LinkMetadataSlotProps` type from the library

## Breaking changes

- `dateStart` and `dateEnd` props removed from `<LoCha>` component
- The "Before: date / After: date" header is no longer rendered by the library

Closes #90

## Test plan

- [ ] Verify `yarn build` succeeds
- [ ] Verify `yarn lint` passes
- [ ] Verify demo app still displays the Before/After header correctly
- [ ] Verify `link-metadata` slot receives correct props when used by a consumer