### PR TITLE
feat: upgrade maplibre-gl peer dependency from v4 to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "maplibre-gl": "^4.7.1",
+    "maplibre-gl": "^5.0.0",
     "vue": "^3.5.13"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Update `maplibre-gl` peer dependency from `^4.7.1` to `^5.0.0`
- Dev dependency was already at `^5.20.2`, so no source code changes needed
- All existing maplibre-gl API usage is compatible with v5

Closes #88

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes