### PR TITLE
feat: make map style URL configurable via prop

### DIFF
--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -3,13 +3,16 @@ import type { LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/type
 import { provide, useId, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
-import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY, REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
+import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY, MAP_STYLE_URL_KEY, REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
+import { MAP_STYLE_URL } from '@/constants/map'
 
 const props = withDefaults(defineProps<{
   data?: LoChaData
+  mapStyleUrl?: string
   reasonCollapsed?: boolean
   hash?: string
 }>(), {
+  mapStyleUrl: MAP_STYLE_URL,
   reasonCollapsed: true,
 })
 
@@ -22,6 +25,7 @@ const instanceId = useId()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
 provide(LOCHA_INSTANCE_ID_KEY, instanceId)
+provide(MAP_STYLE_URL_KEY, props.mapStyleUrl)
 
 const loChaInstance = useLoCha()
 provide(LOCHA_KEY, loChaInstance)

--- a/src/components/MapBbox.vue
+++ b/src/components/MapBbox.vue
@@ -4,9 +4,12 @@ import { onMounted, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL } from '@/constants/map'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   bbox?: string
-}>()
+  mapStyleUrl?: string
+}>(), {
+  mapStyleUrl: MAP_STYLE_URL,
+})
 
 const emit = defineEmits<{
   (e: 'updateBbox', bbox: string): void
@@ -66,7 +69,7 @@ watch(
 onMounted(() => {
   map.value = new maplibre.Map({
     container: 'bbox-selector',
-    style: MAP_STYLE_URL,
+    style: props.mapStyleUrl,
     attributionControl: {
       compact: false,
     },

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -6,7 +6,8 @@ import turfBbox from '@turf/bbox'
 import { featureCollection as turfFeatureCollection } from '@turf/helpers'
 import { vIntersectionObserver } from '@vueuse/components'
 import maplibre from 'maplibre-gl'
-import { shallowRef, watch } from 'vue'
+import { inject, shallowRef, watch } from 'vue'
+import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
 import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
@@ -18,6 +19,8 @@ const props = defineProps<{
   features: LoChaGroup
   bbox?: GeoJSON.BBox
 }>()
+
+const mapStyleUrl = inject(MAP_STYLE_URL_KEY, MAP_STYLE_URL)
 
 type MapMouseEventWithFeatures = MapMouseEvent & {
   features?: maplibre.MapGeoJSONFeature[]
@@ -78,7 +81,7 @@ function initMap() {
           animate: false,
           maxZoom: 17,
         },
-        style: MAP_STYLE_URL,
+        style: mapStyleUrl,
         attributionControl: {
           compact: false,
         },

--- a/src/constants/injectionKeys.ts
+++ b/src/constants/injectionKeys.ts
@@ -4,3 +4,4 @@ import type { LoCha } from '@/types'
 export const REASON_COLLAPSED_KEY: InjectionKey<boolean> = Symbol('reasonCollapsed')
 export const LOCHA_KEY: InjectionKey<LoCha> = Symbol('loCha')
 export const LOCHA_INSTANCE_ID_KEY: InjectionKey<string> = Symbol('loChaInstanceId')
+export const MAP_STYLE_URL_KEY: InjectionKey<string> = Symbol('mapStyleUrl')


### PR DESCRIPTION
## Summary
- Add optional `mapStyleUrl` prop to `LoCha` component with default fallback to existing `MAP_STYLE_URL`
- Propagate via `MAP_STYLE_URL_KEY` injection key to `VMap`
- Add `mapStyleUrl` prop directly to `MapBbox` (demo-only, outside LoCha tree)

### Usage
```vue
<LoCha :data="data" map-style-url="https://my-tiles.example.com/style.json" />
```

Closes #100

## Test plan
- [ ] Verify map renders with default style (no prop passed)
- [ ] Verify map renders with custom style URL passed via prop
- [ ] Verify MapBbox in demo app still works with default and custom URLs