### PR TITLE
fix: normalize bbox for point/node features in map display

### DIFF
--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -37,6 +37,7 @@ const map = shallowRef<maplibre.Map>()
 const isVisible = shallowRef(false)
 const popup = shallowRef<maplibre.Popup>()
 const hoveredStateFeature = shallowRef<maplibre.MapGeoJSONFeature>()
+let normalizedBbox: [number, number, number, number] | undefined
 
 watch(isVisible, (newState) => {
   if (newState) {
@@ -60,8 +61,10 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
-    const clipped = props.bbox
-      ? clipAndEnvelope(props.features, normalizeBbox(props.bbox))
+    normalizedBbox = props.bbox ? normalizeBbox(props.bbox) : undefined
+
+    const clipped = normalizedBbox
+      ? clipAndEnvelope(props.features, normalizedBbox)
       : turfFeatureCollection(props.features)
 
     if (clipped) {
@@ -122,8 +125,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (props.bbox) {
-    displayBbox(normalizeBbox(props.bbox))
+  if (normalizedBbox) {
+    displayBbox(normalizedBbox)
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -65,7 +65,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = turfBbox(clipped)
+      const boundsArray = normalizeBbox(turfBbox(clipped))
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
@@ -123,7 +123,7 @@ function handleMapOnLoad(): void {
     throw new Error('Call initMap() function first.')
 
   if (props.bbox) {
-    displayBbox(props.bbox)
+    displayBbox(normalizeBbox(props.bbox))
   }
 
   map.value!.addSource(SOURCE_ID, {


### PR DESCRIPTION
## Summary

- Apply `normalizeBbox()` to the bbox passed to `displayBbox()` so zero-area bboxes from point features render as visible polygons
- Apply `normalizeBbox()` to the bounds computed by `turfBbox()` so `fitBounds` works correctly for point-only features

Closes #105