### PR TITLE
fix: add cooperativeGestures to VMap

### DIFF
--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -85,6 +85,7 @@ function initMap() {
           maxZoom: 17,
         },
         style: mapStyleUrl,
+        cooperativeGestures: true,
         attributionControl: {
           compact: false,
         },


### PR DESCRIPTION
## Summary

- Add `cooperativeGestures: true` to MapLibre map options in `VMap.vue`
- Prevents scroll hijacking when scrolling through pages with multiple LoCha cards
- Aligns behavior with the frontend's `DiffMap` component

Closes #109