### PR TITLE
Release v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -85,6 +85,7 @@ function initMap() {
           maxZoom: 17,
         },
         style: mapStyleUrl,
+        cooperativeGestures: true,
         attributionControl: {
           compact: false,
         },

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -37,6 +37,7 @@ const map = shallowRef<maplibre.Map>()
 const isVisible = shallowRef(false)
 const popup = shallowRef<maplibre.Popup>()
 const hoveredStateFeature = shallowRef<maplibre.MapGeoJSONFeature>()
+let normalizedBbox: [number, number, number, number] | undefined
 
 watch(isVisible, (newState) => {
   if (newState) {
@@ -60,8 +61,10 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
-    const clipped = props.bbox
-      ? clipAndEnvelope(props.features, normalizeBbox(props.bbox))
+    normalizedBbox = props.bbox ? normalizeBbox(props.bbox) : undefined
+
+    const clipped = normalizedBbox
+      ? clipAndEnvelope(props.features, normalizedBbox)
       : turfFeatureCollection(props.features)
 
     if (clipped) {
@@ -122,8 +125,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (props.bbox) {
-    displayBbox(normalizeBbox(props.bbox))
+  if (normalizedBbox) {
+    displayBbox(normalizedBbox)
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -65,7 +65,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = turfBbox(clipped)
+      const boundsArray = normalizeBbox(turfBbox(clipped))
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
@@ -123,7 +123,7 @@ function handleMapOnLoad(): void {
     throw new Error('Call initMap() function first.')
 
   if (props.bbox) {
-    displayBbox(props.bbox)
+    displayBbox(normalizeBbox(props.bbox))
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -46,25 +46,16 @@ export function clipAndEnvelope(
   return turfEnvelope(fc)
 }
 
-// ~100m padding in degrees, used to expand degenerate (zero-area) bboxes
+// ~100m epsilon padding in degrees, ensures features on bbox edges are not excluded
 const BBOX_PADDING = 0.001
 
 export function normalizeBbox(
   bbox: GeoJSON.BBox,
 ): [number, number, number, number] {
-  let minX = bbox[0]
-  let minY = bbox[1]
-  let maxX = bbox[2]
-  let maxY = bbox[3]
-
-  if (minX === maxX) {
-    minX -= BBOX_PADDING
-    maxX += BBOX_PADDING
-  }
-  if (minY === maxY) {
-    minY -= BBOX_PADDING
-    maxY += BBOX_PADDING
-  }
-
-  return [minX, minY, maxX, maxY]
+  return [
+    bbox[0] - BBOX_PADDING,
+    bbox[1] - BBOX_PADDING,
+    bbox[2] + BBOX_PADDING,
+    bbox[3] + BBOX_PADDING,
+  ]
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -97,15 +97,22 @@ describe('clipAndEnvelope', () => {
 })
 
 describe('normalizeBbox', () => {
-  it('returns bbox unchanged when non-degenerate and no swap needed', () => {
-    // minX and maxX outside [-90, 90] → no swap
+  it('always adds epsilon padding to non-degenerate bbox', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([-122.5, 37.7, -122.4, 37.8])
+    const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
+    expect(result[3]).toBeGreaterThan(37.8)
   })
 
-  it('returns bbox unchanged when already in standard GeoJSON format', () => {
+  it('adds epsilon padding in standard GeoJSON format', () => {
     const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([43.4, -1.6, 43.5, -1.5])
+    const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(43.4)
+    expect(result[1]).toBeLessThan(-1.6)
+    expect(result[2]).toBeGreaterThan(43.5)
+    expect(result[3]).toBeGreaterThan(-1.5)
   })
 
   it('pads degenerate bbox where minX === maxX', () => {
@@ -113,17 +120,17 @@ describe('normalizeBbox', () => {
     const result = normalizeBbox(bbox)
     expect(result[0]).toBeLessThan(-122.5)
     expect(result[2]).toBeGreaterThan(-122.5)
-    expect(result[1]).toBe(37.7)
-    expect(result[3]).toBe(37.8)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[3]).toBeGreaterThan(37.8)
   })
 
   it('pads degenerate bbox where minY === maxY', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.7] as [number, number, number, number]
     const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
     expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
     expect(result[3]).toBeGreaterThan(37.7)
-    expect(result[0]).toBe(-122.5)
-    expect(result[2]).toBe(-122.4)
   })
 
   it('pads fully degenerate bbox (single point)', () => {
@@ -133,5 +140,10 @@ describe('normalizeBbox', () => {
     expect(result[2]).toBeGreaterThan(-1.572)
     expect(result[1]).toBeLessThan(43.457)
     expect(result[3]).toBeGreaterThan(43.457)
+  })
+
+  it('applies exact BBOX_PADDING of 0.001', () => {
+    const bbox = [0, 0, 10, 10] as [number, number, number, number]
+    expect(normalizeBbox(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
   })
 })


### PR DESCRIPTION
## Summary
- fix: add cooperativeGestures to VMap to prevent scroll hijacking
- fix: always add epsilon padding in normalizeBbox to prevent clipping edge features
- refactor: compute normalizedBbox once and reuse across initMap and handleMapOnLoad
- fix: normalize bbox for point/node features in map display
- chore: bump version to 0.3.1