### PR TITLE
Add group-actions slot at LoChaGroup level

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ Additional slot props on "after" features only:
 | `title` | `string`                 | A label for the tag diff.               |
 | `dst`   | `IFeature['properties']` | Destination (after) feature properties. |
 
+#### `#link-metadata`
+
+A scoped slot rendered once per group in the full-width header area, allowing custom rendering of link metadata.
+
+| Prop    | Type        | Description                                    |
+| ------- | ----------- | ---------------------------------------------- |
+| `index` | `number`    | The group index.                               |
+| `links` | `ApiLink[]` | The array of links associated with this group. |
+
+#### `#group-actions`
+
+A scoped slot rendered once per group, positioned to the right of the link metadata header. Useful for injecting per-group action buttons (e.g. accept/reject validation).
+
+| Prop    | Type        | Description                                    |
+| ------- | ----------- | ---------------------------------------------- |
+| `index` | `number`    | The group index.                               |
+| `links` | `ApiLink[]` | The array of links associated with this group. |
+
+Example usage:
+
+```vue
+<LoCha :data="data" map-style-url="...">
+  <template #group-actions="{ index, links }">
+    <button @click="acceptGroup(index)">Accept</button>
+  </template>
+</LoCha>
+```
+
 ### Types
 
 All consumer-facing types are exported from the package entry point:

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -19,6 +19,7 @@ const props = withDefaults(defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const instanceId = useId()
@@ -53,6 +54,9 @@ watch(() => props.data, (newValue) => {
       </template>
       <template #link-metadata="slotProps">
         <slot name="link-metadata" v-bind="slotProps" />
+      </template>
+      <template #group-actions="slotProps">
+        <slot name="group-actions" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -58,7 +58,7 @@ function getTagsTitle(link: ApiLink): string {
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
-      <div class="group-actions">
+      <div v-if="$slots['group-actions']" class="group-actions">
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
@@ -53,8 +54,13 @@ function getTagsTitle(link: ApiLink): string {
 
 <template>
   <div class="locha-group">
-    <div class="link-metadata">
-      <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
+    <div class="group-header">
+      <div class="link-metadata">
+        <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
+      </div>
+      <div class="group-actions">
+        <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
+      </div>
     </div>
     <div class="before-list">
       <ul>
@@ -116,8 +122,17 @@ function getTagsTitle(link: ApiLink): string {
   padding: 8px;
 }
 
-.link-metadata {
+.group-header {
   grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.link-metadata {
+  flex: 1;
+  min-width: 0;
 }
 
 .before-list {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!
@@ -50,6 +51,9 @@ watch(() => props.hash, (newValue) => {
           </template>
           <template #link-metadata="slotProps">
             <slot name="link-metadata" v-bind="slotProps" />
+          </template>
+          <template #group-actions="slotProps">
+            <slot name="group-actions" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>


### PR DESCRIPTION
## Summary
- Add a new `#group-actions` slot rendered once per group in `LoChaGroup`
- Slot receives `index` and `links` as props (same as `#link-metadata`)
- Forwarded through the full hierarchy: `LoCha → LoChaGroupList → LoChaGroup`
- Wrapped `link-metadata` and `group-actions` in a `group-header` flex container for side-by-side layout

## Usage

```vue
<LoCha :data="loCha" :map-style-url="mapStyleUrl">
  <template #group-actions="{ index, links }">
    <button @click="acceptGroup(index)">✓</button>
  </template>
</LoCha>
```

## Test plan
- [ ] Verify the slot renders once per group with correct `index` and `links` props
- [ ] Verify existing `#link-metadata` and `#tags-diff` slots still work as before
- [ ] Verify layout: `link-metadata` takes available space, `group-actions` sits to the right

Closes #112