### PR TITLE
Use required id prop for deterministic anchor targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ const data = ref<ApiResponse>()
 
 ### Props
 
-| Prop              | Type          | Default     | Description                                                   |
-| ----------------- | ------------- | ----------- | ------------------------------------------------------------- |
-| `data`            | `ApiResponse` | `undefined` | The API response containing features and metadata to display. |
-| `reasonCollapsed` | `boolean`     | `true`      | Whether conflation reason details are collapsed by default.   |
+| Prop              | Type          | Default     | Description                                                                    |
+| ----------------- | ------------- | ----------- | ------------------------------------------------------------------------------ |
+| `id`              | `string`      | —           | **Required.** A unique, deterministic identifier used to build anchor targets. |
+| `data`            | `ApiResponse` | `undefined` | The API response containing features and metadata to display.                  |
+| `reasonCollapsed` | `boolean`     | `true`      | Whether conflation reason details are collapsed by default.                    |
 
 ### Slots
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@ function handleSubmit(data: FormData) {
       <h2>Before : {{ dateFrom }}</h2>
       <h2>After : {{ dateTo }}</h2>
     </div>
-    <LoCha :data="geojson" :reason-collapsed="false">
+    <LoCha id="demo" :data="geojson" :reason-collapsed="false">
       <template #tags-diff="{ title, date, diff, dst, src, reason }">
         <div class="infos">
           <span v-if="title" class="title">🔗 {{ title }}</span>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import type { LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
-import { provide, useId, watch } from 'vue'
+import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY, MAP_STYLE_URL_KEY, REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 
 const props = withDefaults(defineProps<{
+  id: string
   data?: LoChaData
   mapStyleUrl?: string
   reasonCollapsed?: boolean
@@ -22,10 +23,8 @@ defineSlots<{
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
-const instanceId = useId()
-
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
-provide(LOCHA_INSTANCE_ID_KEY, instanceId)
+provide(LOCHA_INSTANCE_ID_KEY, props.id)
 provide(MAP_STYLE_URL_KEY, props.mapStyleUrl)
 
 const loChaInstance = useLoCha()


### PR DESCRIPTION
## Summary
- Replace `useId()` with a required `id` prop on `LoCha` for deterministic DOM IDs
- Anchor targets become predictable from data (e.g. `locha-{id}-group-{index}`)
- Enables consuming apps to navigate to a specific group without rendering all components first

## Breaking change
The `id` prop is now **required** on `<LoCha>`. Consumers must provide a unique, deterministic identifier:
```vue
<LoCha id="my-locha" :data="data" />
```

## Test plan
- [ ] Verify anchor IDs are deterministic across reloads with same `id` prop
- [ ] Verify anchor click + hash scroll still works
- [ ] Verify map containers and JOSM targets use the provided `id`
- [ ] Verify TypeScript error if `id` prop is omitted

Closes #117