### PR TITLE
Move anchor button inside LoChaGroup header

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -6,9 +6,14 @@ import VMap from '@/components/VMap.vue'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
 
 const props = defineProps<{
+  id: string
   index: number
   features: LoChaGroup
   josmTarget?: string
+}>()
+
+defineEmits<{
+  navigate: [hash: string]
 }>()
 
 defineSlots<{
@@ -53,8 +58,9 @@ function getTagsTitle(link: ApiLink): string {
 </script>
 
 <template>
-  <div class="locha-group">
+  <div :id="id" class="locha-group">
     <div class="group-header">
+      <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
@@ -128,6 +134,13 @@ function getTagsTitle(link: ApiLink): string {
   justify-content: space-between;
   align-items: flex-start;
   gap: 0.5rem;
+}
+
+.anchor-button {
+  border: 2px solid #cecece;
+  background-color: #ffffff;
+  text-decoration: none;
+  padding: 0.25rem;
 }
 
 .link-metadata {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -57,8 +57,7 @@ onMounted(() => {
   <div ref="listRef" class="locha-group-list">
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
-        <a class="anchor-button" :href="`#${groupId(index)}`" @click.prevent="navigateToHash(`#${groupId(index)}`)">🔗</a>
-        <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()">
+        <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()" @navigate="navigateToHash">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />
           </template>
@@ -100,26 +99,8 @@ onMounted(() => {
   background-clip: content-box;
 }
 
-.locha-group-list > ul > li {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-}
-
 .locha-group-list > ul > li.selected .locha-group {
   border-color: v-bind(highlightBorderColor);
-}
-
-.locha-group-list > ul > li > div {
-  flex: 1;
-  min-width: 0;
-}
-
-.anchor-button {
-  border: 2px solid #cecece;
-  background-color: #ffffff;
-  text-decoration: none;
-  padding: 0.25rem;
 }
 
 ul {


### PR DESCRIPTION
## Summary

- Move the anchor link (🔗) from `LoChaGroupList` into `LoChaGroup`'s `.group-header`, so the header follows: **anchor / link-metadata / group-actions**
- Add an explicit `id` prop on `LoChaGroup` and a `navigate` emit; `LoChaGroupList` listens for `@navigate` to handle scroll + hash state
- Simplify `LoChaGroupList` styles (no more flex row on `<li>`, anchor CSS migrated to `LoChaGroup`)

Closes #121