### PR TITLE
feat: add cycling background color on LoChaGroup for visual separation

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ApiLink, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
@@ -21,6 +21,9 @@ defineSlots<{
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
+
+const groupBackgroundPalette = ['#ededee', '#f0f0f1', '#f4f4f6', '#fafbfd']
+const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -124,7 +127,7 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   border: 2px solid #cecece;
-  background-color: #ffffff;
+  background-color: v-bind(groupBackground);
   padding: 8px;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -22,7 +22,7 @@ defineSlots<{
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
-const groupBackgroundPalette = ['#ededee', '#f0f0f1', '#f4f4f6', '#fafbfd']
+const groupBackgroundPalette = ['#e0e0e2', '#e8e8ea', '#f0f0f2', '#f8f8fa']
 const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!


### PR DESCRIPTION
## Summary
- Add a 4-color light grey palette cycled by group index on `LoChaGroup` background
- Palette: `#ededee`, `#f0f0f1`, `#f4f4f6`, `#fafbfd` (lightened from the original clearance-frontend border colors for full-background use)
- Applied to every group via `v-bind()` CSS, using a computed property based on `props.index`
- Selected-state outer border remains unchanged

Closes #120

## Test plan
- [ ] Open demo app with a dataset producing >4 groups — verify cycling background is visible
- [ ] Verify text contrast remains readable on all 4 tints
- [ ] Verify selected-state border highlight still works on top of tinted backgrounds