### PR TITLE
refactor: split normalizeBbox into clipping and display variants

### DIFF
--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -61,14 +61,14 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
-    normalizedBbox = props.bbox ? normalizeBbox(props.bbox) : undefined
+    normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
 
     const clipped = normalizedBbox
       ? clipAndEnvelope(props.features, normalizedBbox)
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = normalizeBbox(turfBbox(clipped))
+      const boundsArray = normalizeBboxForDisplay(turfBbox(clipped))
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -46,16 +46,25 @@ export function clipAndEnvelope(
   return turfEnvelope(fc)
 }
 
-// ~100m epsilon padding in degrees, ensures features on bbox edges are not excluded
-const BBOX_PADDING = 0.001
+// ~100m padding in degrees, ensures features on bbox edges are not excluded during clipping
+const CLIPPING_PADDING = 0.001
 
-export function normalizeBbox(
-  bbox: GeoJSON.BBox,
-): [number, number, number, number] {
+// ~10m padding in degrees, used for map display bounds (smaller to avoid over-zooming on degenerate bboxes)
+const DISPLAY_PADDING = 0.0001
+
+function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
-    bbox[0] - BBOX_PADDING,
-    bbox[1] - BBOX_PADDING,
-    bbox[2] + BBOX_PADDING,
-    bbox[3] + BBOX_PADDING,
+    bbox[0] - padding,
+    bbox[1] - padding,
+    bbox[2] + padding,
+    bbox[3] + padding,
   ]
+}
+
+export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, number, number] {
+  return padBbox(bbox, CLIPPING_PADDING)
+}
+
+export function normalizeBboxForDisplay(bbox: GeoJSON.BBox): [number, number, number, number] {
+  return padBbox(bbox, DISPLAY_PADDING)
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -96,54 +96,59 @@ describe('clipAndEnvelope', () => {
   })
 })
 
-describe('normalizeBbox', () => {
-  it('always adds epsilon padding to non-degenerate bbox', () => {
+describe('normalizeBboxForClipping', () => {
+  it('adds ~100m padding to non-degenerate bbox', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
+    const result = normalizeBboxForClipping(bbox)
     expect(result[0]).toBeLessThan(-122.5)
     expect(result[1]).toBeLessThan(37.7)
     expect(result[2]).toBeGreaterThan(-122.4)
     expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('adds epsilon padding in standard GeoJSON format', () => {
-    const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(43.4)
-    expect(result[1]).toBeLessThan(-1.6)
-    expect(result[2]).toBeGreaterThan(43.5)
-    expect(result[3]).toBeGreaterThan(-1.5)
-  })
-
-  it('pads degenerate bbox where minX === maxX', () => {
-    const bbox = [-122.5, 37.7, -122.5, 37.8] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[2]).toBeGreaterThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('pads degenerate bbox where minY === maxY', () => {
-    const bbox = [-122.5, 37.7, -122.4, 37.7] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[2]).toBeGreaterThan(-122.4)
-    expect(result[3]).toBeGreaterThan(37.7)
   })
 
   it('pads fully degenerate bbox (single point)', () => {
     const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
+    const result = normalizeBboxForClipping(bbox)
     expect(result[0]).toBeLessThan(-1.572)
     expect(result[2]).toBeGreaterThan(-1.572)
     expect(result[1]).toBeLessThan(43.457)
     expect(result[3]).toBeGreaterThan(43.457)
   })
 
-  it('applies exact BBOX_PADDING of 0.001', () => {
+  it('applies exact clipping padding of 0.001', () => {
     const bbox = [0, 0, 10, 10] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
+    expect(normalizeBboxForClipping(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
+  })
+})
+
+describe('normalizeBboxForDisplay', () => {
+  it('adds ~10m padding to non-degenerate bbox', () => {
+    const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
+    const result = normalizeBboxForDisplay(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
+    expect(result[3]).toBeGreaterThan(37.8)
+  })
+
+  it('pads fully degenerate bbox (single point)', () => {
+    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
+    const result = normalizeBboxForDisplay(bbox)
+    expect(result[0]).toBeLessThan(-1.572)
+    expect(result[2]).toBeGreaterThan(-1.572)
+    expect(result[1]).toBeLessThan(43.457)
+    expect(result[3]).toBeGreaterThan(43.457)
+  })
+
+  it('applies exact display padding of 0.0001', () => {
+    const bbox = [0, 0, 10, 10] as [number, number, number, number]
+    expect(normalizeBboxForDisplay(bbox)).toEqual([-0.0001, -0.0001, 10.0001, 10.0001])
+  })
+
+  it('applies smaller padding than clipping variant', () => {
+    const bbox = [0, 0, 0, 0] as [number, number, number, number]
+    const clipping = normalizeBboxForClipping(bbox)
+    const display = normalizeBboxForDisplay(bbox)
+    expect(Math.abs(display[0])).toBeLessThan(Math.abs(clipping[0]))
   })
 })


### PR DESCRIPTION
## Summary
- Split `normalizeBbox` into `normalizeBboxForClipping` (0.001° ~100m) and `normalizeBboxForDisplay` (0.0001° ~10m)
- Use clipping variant for feature filtering, display variant for map bounds
- Reduces over-zooming on degenerate bboxes (e.g., single points that previously showed a ~200m×200m rectangle)

Closes #124

## Test plan
- [ ] Open a dataset with point-only features — verify the bbox rectangle is now ~20m×20m instead of ~200m×200m
- [ ] Open a dataset with polygon/line features — verify clipping still works correctly (no features excluded at edges)
- [ ] Verify map zoom level is appropriate for both degenerate and normal bboxes