### PR TITLE
feat: replace navigation control with fullscreen and remove attribution in VMap

### DIFF
--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -86,11 +86,9 @@ function initMap() {
         },
         style: mapStyleUrl,
         cooperativeGestures: true,
-        attributionControl: {
-          compact: false,
-        },
+        attributionControl: false,
       })
-      map.value.addControl(new maplibre.NavigationControl())
+      map.value.addControl(new maplibre.FullscreenControl())
 
       map.value.on('load', handleMapOnLoad)
     }


### PR DESCRIPTION
## Summary
- Remove NavigationControl (zoom +/−, compass) from per-group maps
- Remove attribution display
- Add FullscreenControl

Only affects VMap.vue (per-group maps), not MapBbox.vue (bbox selector).

Closes #125

## Test plan
- [ ] Verify per-group maps no longer show zoom/compass controls
- [ ] Verify attribution is hidden
- [ ] Verify fullscreen button appears and works
- [ ] Verify MapBbox still has its own controls unchanged