### PR TITLE
feat: move object name to LoChaGroup header with uniq before/after display

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -155,6 +155,12 @@ function getTagsTitle(link: ApiLink): string {
   gap: 0.5rem;
 }
 
+.group-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
 .anchor-button {
   border: 2px solid #cecece;
   background-color: #ffffff;

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -48,6 +48,19 @@ function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined 
   return loCha.value!.features.find(feature => feature.id === link!.before)?.properties
 }
 
+const groupName = computed(() => {
+  const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+  const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+
+  const beforeLabel = beforeNames.length > 0 ? beforeNames.join(', ') : '(unnamed)'
+  const afterLabel = afterNames.length > 0 ? afterNames.join(', ') : '(unnamed)'
+
+  if (beforeLabel === afterLabel)
+    return beforeLabel
+
+  return `${beforeLabel} → ${afterLabel}`
+})
+
 function getTagsTitle(link: ApiLink): string {
   let title = ''
 
@@ -64,6 +77,9 @@ function getTagsTitle(link: ApiLink): string {
   <div :id="id" class="locha-group">
     <div class="group-header">
       <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
+      <h3 class="group-name">
+        {{ groupName }}
+      </h3>
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
@@ -134,7 +150,7 @@ function getTagsTitle(link: ApiLink): string {
 .group-header {
   grid-column: 1 / -1;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
 }

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -53,7 +53,6 @@ const color = computed(() => loChaColors[status.value])
           {{ statusContent }}
         </div>
       </div>
-      <h3>{{ props.feature.properties.tags.name }}</h3>
       <p class="date">
         📅 {{ props.feature.properties.created }}
       </p>
@@ -116,10 +115,6 @@ article {
   flex-direction: column;
   gap: 4px;
   padding: 0.25rem;
-}
-
-h3 {
-  font-weight: 400;
 }
 
 header > a {


### PR DESCRIPTION
## Summary
- Move feature name display from individual LoChaObject cards to LoChaGroup header
- Compute unique names from before/after features
- Show single name when unchanged, arrow format (Old → New) on rename
- Use (unnamed) placeholder when no name exists on either side
- Multiple distinct names on same side are comma-joined after dedup
- Remove unused `<h3>` and its CSS from LoChaObject

Closes #122

## Test plan
- [ ] Verify name appears once in group header instead of per-object
- [ ] Verify rename shows arrow format (Old Name → New Name)
- [ ] Verify unnamed features show (unnamed) placeholder
- [ ] Verify multi-feature groups with different names show comma-joined names
- [ ] Verify creation shows (unnamed) → Name, deletion shows Name → (unnamed)