### PR TITLE
feat: add changesets slot at LoChaGroup level

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,30 @@ A scoped slot rendered once per group, positioned to the right of the link metad
 | `index` | `number`    | The group index.                               |
 | `links` | `ApiLink[]` | The array of links associated with this group. |
 
+#### `#changesets`
+
+A scoped slot rendered once per group as the first column (before the "before" column). When provided, the grid switches from 3 to 4 columns. When omitted, the layout remains unchanged at 3 columns.
+
+| Prop         | Type          | Description                                         |
+| ------------ | ------------- | --------------------------------------------------- |
+| `index`      | `number`      | The group index.                                    |
+| `changesets` | `Changeset[]` | The full array of changesets from the API response. |
+
+> **Note:** The `changesets` array contains all changesets from the response, not filtered per group. The consumer is responsible for filtering relevant changesets (e.g. by matching `changeset_id` from feature properties against `Changeset.id`).
+
 Example usage:
 
 ```vue
 <LoCha :data="data" map-style-url="...">
   <template #group-actions="{ index, links }">
     <button @click="acceptGroup(index)">Accept</button>
+  </template>
+  <template #changesets="{ changesets, index }">
+    <ul>
+      <li v-for="cs in changesets" :key="cs.id">
+        {{ cs.user }} — {{ cs.tags?.comment }}
+      </li>
+    </ul>
   </template>
 </LoCha>
 ```
@@ -115,10 +133,14 @@ import type {
   ApiLink,
   ApiLinkGroups,
   ApiResponse,
+  Changeset,
+  ChangesetsSlotProps,
   IFeature,
+  LinkMetadataSlotProps,
   Reason,
   ReasonGeom,
   ReasonTags,
+  TagsDiffSlotProps,
 } from '@teritorio/openstreetmap-logical-history-component'
 ```
 

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
+import type { ChangesetsSlotProps, LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -21,6 +21,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
@@ -56,6 +57,9 @@ watch(() => props.data, (newValue) => {
       </template>
       <template #group-actions="slotProps">
         <slot name="group-actions" v-bind="slotProps" />
+      </template>
+      <template #changesets="slotProps">
+        <slot name="changesets" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
+import type { ApiLink, ChangesetsSlotProps, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
 import { computed, inject } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
@@ -16,14 +16,16 @@ defineEmits<{
   navigate: [hash: string]
 }>()
 
-defineSlots<{
+const slots = defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 const groupBackgroundPalette = ['#e0e0e2', '#e8e8ea', '#f0f0f2', '#f8f8fa']
 const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
+const gridColumns = computed(() => slots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -87,6 +89,9 @@ function getTagsTitle(link: ApiLink): string {
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>
+    <div v-if="slots.changesets" class="changesets-list">
+      <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
+    </div>
     <div class="before-list">
       <ul>
         <li
@@ -140,7 +145,7 @@ function getTagsTitle(link: ApiLink): string {
 <style lang="css" scoped>
 .locha-group {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: v-bind(gridColumns);
   gap: 1rem;
   border: 2px solid #cecece;
   background-color: v-bind(groupBackground);
@@ -176,16 +181,7 @@ function getTagsTitle(link: ApiLink): string {
   gap: 0.3em;
 }
 
-.before-list {
-  grid-column: 1;
-}
-
-.after-list {
-  grid-column: 2;
-}
-
 .v-map {
-  grid-column: 3;
   border: 1px solid #000000;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -89,7 +89,7 @@ function getTagsTitle(link: ApiLink): string {
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>
-    <div v-if="slots.changesets" class="changesets-list">
+    <div v-if="$slots.changesets" class="changesets-list">
       <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
     </div>
     <div class="before-list">

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
+import type { ChangesetsSlotProps, LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
 import { inject, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors } from '@/composables/useLoCha'
@@ -14,6 +14,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!
@@ -66,6 +67,9 @@ onMounted(() => {
           </template>
           <template #group-actions="slotProps">
             <slot name="group-actions" v-bind="slotProps" />
+          </template>
+          <template #changesets="slotProps">
+            <slot name="changesets" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export type {
   ActionTypeOptions,
   ApiLink,
   ApiLinkGroups,
+  Changeset,
+  ChangesetsSlotProps,
   IFeature,
   LinkMetadataSlotProps,
   LoChaData,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { Actions, ApiLink, IFeature, LoChaData, Reason } from './api'
+import type { Actions, ApiLink, Changeset, IFeature, LoChaData, Reason } from './api'
 
 /**
  * The possible statuses for features in the system.
@@ -45,6 +45,14 @@ export interface TagsDiffSlotProps {
  */
 export interface LinkMetadataSlotProps {
   links: ApiLink[]
+  index: number
+}
+
+/**
+ * Props passed through the `changesets` slot across the LoCha component hierarchy.
+ */
+export interface ChangesetsSlotProps {
+  changesets: Changeset[]
   index: number
 }
 


### PR DESCRIPTION
## Summary
- Add new `changesets` slot forwarded through the full component chain (LoCha → LoChaGroupList → LoChaGroup)
- Slot receives `{ changesets: Changeset[], index: number }` — all changesets + group index, letting the consumer filter and render
- Column is conditionally rendered: 3-column grid without slot, 4-column grid when slot is provided
- New `ChangesetsSlotProps` type exported from the package entry
- `Changeset` type also exported for consumer convenience

Closes #119

## Test plan
- [ ] Verify layout remains 3 columns when `changesets` slot is not provided
- [ ] Verify layout switches to 4 columns when `changesets` slot is provided
- [ ] Verify slot receives correct `changesets` array and `index`
- [ ] Verify slot forwarding works through all 3 component levels