### PR TITLE
Move action buttons to top-right corner of object header

### DIFF
--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -52,6 +52,44 @@ const color = computed(() => loChaColors[status.value])
         >
           {{ statusContent }}
         </div>
+        <div class="actions">
+          <a
+            :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="Edit in OSM iD"
+            target="_blank"
+            @click.stop
+          >
+            OSM iD
+          </a>
+          <a
+            :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="Edit in JOSM"
+            :target="josmTarget || 'hidden_josm_target'"
+            @click.stop
+          >
+            JOSM
+          </a>
+          <a
+            :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="OSM Deep History"
+            target="_blank"
+            @click.stop
+          >
+            Deep H
+          </a>
+          <a
+            :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="OSM History Viewer"
+            target="_blank"
+            @click.stop
+          >
+            OSM H
+          </a>
+        </div>
       </div>
       <p class="date">
         📅 {{ props.feature.properties.created }}
@@ -66,44 +104,6 @@ const color = computed(() => loChaColors[status.value])
       </a>
     </header>
     <slot name="tags-diff" />
-    <div class="actions">
-      <a
-        :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="Edit in OSM iD"
-        target="_blank"
-        @click.stop
-      >
-        OSM iD
-      </a>
-      <a
-        :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="Edit in JOSM"
-        :target="josmTarget || 'hidden_josm_target'"
-        @click.stop
-      >
-        JOSM
-      </a>
-      <a
-        :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="OSM Deep History"
-        target="_blank"
-        @click.stop
-      >
-        Deep H
-      </a>
-      <a
-        :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="OSM History Viewer"
-        target="_blank"
-        @click.stop
-      >
-        OSM H
-      </a>
-    </div>
   </article>
 </template>
 
@@ -125,11 +125,12 @@ header > a {
 .wrap {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.25rem;
 }
 
 .actions {
   display: flex;
+  margin-left: auto;
 }
 
 :deep(.date),

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -55,7 +55,7 @@ const color = computed(() => loChaColors[status.value])
         <div class="actions">
           <a
             :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="Edit in OSM iD"
             target="_blank"
             @click.stop
@@ -64,7 +64,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="Edit in JOSM"
             :target="josmTarget || 'hidden_josm_target'"
             @click.stop
@@ -73,7 +73,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="OSM Deep History"
             target="_blank"
             @click.stop
@@ -82,7 +82,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="OSM History Viewer"
             target="_blank"
             @click.stop
@@ -124,6 +124,7 @@ header > a {
 
 .wrap {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.25rem;
 }
@@ -131,6 +132,7 @@ header > a {
 .actions {
   display: flex;
   margin-left: auto;
+  flex-shrink: 0;
 }
 
 :deep(.date),
@@ -144,7 +146,7 @@ header > a {
   gap: 0.5rem;
 }
 
-[type='button'] {
+.action-btn {
   flex-grow: 1;
   color: #000000;
   padding: 0.5em 1em;


### PR DESCRIPTION
## Summary
- Move OSM iD, JOSM, Deep H, and OSM H action buttons from the bottom of `LoChaObject` into the header `.wrap` div
- Buttons are now aligned to the right, at the same level as the id-version link
- Adjust CSS: use `margin-left: auto` on `.actions` for right-alignment within flexbox

Closes #131

## Test plan
- [ ] Verify action buttons appear in the top-right corner of each object
- [ ] Verify buttons remain functional (links open correctly)
- [ ] Check layout with status badge (new/deleted) present
- [ ] Check responsive behavior on narrow viewports