### PR TITLE
refactor!: generalize slot names and props to position-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,68 +55,53 @@ const data = ref<ApiResponse>()
 
 ### Slots
 
-#### `#tags-diff`
+All slots are optional and receive generic, position-based props. The LoCha component does not perform domain-specific data lookups — consumers are responsible for their own data processing.
 
-A scoped slot exposed on each feature group, allowing custom rendering of tag diffs.
+#### `#object-detail`
 
-Slot props (always present):
+A scoped slot rendered once per feature inside each object card. Use it to display tag diffs, validation status, or any per-feature content.
 
-| Prop     | Type                     | Description                                                                                                               |
-| -------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `date`   | `string`                 | The feature's creation date.                                                                                              |
-| `diff`   | `Actions`                | The tag diff actions.                                                                                                     |
-| `reason` | `Reason`                 | The conflation reason.                                                                                                    |
-| `src`    | `IFeature['properties']` | Source feature properties. On "before" features this is the feature itself; on "after" it is the linked "before" feature. |
+| Prop      | Type       | Description              |
+| --------- | ---------- | ------------------------ |
+| `feature` | `IFeature` | The feature being shown. |
+| `index`   | `number`   | The group index.         |
 
-Additional slot props on "after" features only:
+#### `#header-center`
 
-| Prop    | Type                     | Description                             |
-| ------- | ------------------------ | --------------------------------------- |
-| `title` | `string`                 | A label for the tag diff.               |
-| `dst`   | `IFeature['properties']` | Destination (after) feature properties. |
+A scoped slot rendered once per group in the center of the group header (between the group name and the end slot).
 
-#### `#link-metadata`
+| Prop    | Type     | Description      |
+| ------- | -------- | ---------------- |
+| `index` | `number` | The group index. |
 
-A scoped slot rendered once per group in the full-width header area, allowing custom rendering of link metadata.
+#### `#header-end`
 
-| Prop    | Type        | Description                                    |
-| ------- | ----------- | ---------------------------------------------- |
-| `index` | `number`    | The group index.                               |
-| `links` | `ApiLink[]` | The array of links associated with this group. |
+A scoped slot rendered once per group at the right end of the group header. Useful for injecting per-group action buttons (e.g. accept/reject validation).
 
-#### `#group-actions`
+| Prop    | Type     | Description      |
+| ------- | -------- | ---------------- |
+| `index` | `number` | The group index. |
 
-A scoped slot rendered once per group, positioned to the right of the link metadata header. Useful for injecting per-group action buttons (e.g. accept/reject validation).
-
-| Prop    | Type        | Description                                    |
-| ------- | ----------- | ---------------------------------------------- |
-| `index` | `number`    | The group index.                               |
-| `links` | `ApiLink[]` | The array of links associated with this group. |
-
-#### `#changesets`
+#### `#content-start`
 
 A scoped slot rendered once per group as the first column (before the "before" column). When provided, the grid switches from 3 to 4 columns. When omitted, the layout remains unchanged at 3 columns.
 
-| Prop         | Type          | Description                                         |
-| ------------ | ------------- | --------------------------------------------------- |
-| `index`      | `number`      | The group index.                                    |
-| `changesets` | `Changeset[]` | The full array of changesets from the API response. |
-
-> **Note:** The `changesets` array contains all changesets from the response, not filtered per group. The consumer is responsible for filtering relevant changesets (e.g. by matching `changeset_id` from feature properties against `Changeset.id`).
+| Prop    | Type     | Description      |
+| ------- | -------- | ---------------- |
+| `index` | `number` | The group index. |
 
 Example usage:
 
 ```vue
 <LoCha :data="data" map-style-url="...">
-  <template #group-actions="{ index, links }">
+  <template #object-detail="{ feature, index }">
+    <!-- Custom per-feature rendering -->
+  </template>
+  <template #header-end="{ index }">
     <button @click="acceptGroup(index)">Accept</button>
   </template>
-  <template #changesets="{ changesets, index }">
-    <ul>
-      <li v-for="cs in changesets" :key="cs.id">
-        {{ cs.user }} — {{ cs.tags?.comment }}
-      </li>
-    </ul>
+  <template #content-start="{ index }">
+    <!-- Custom first-column content (e.g. changesets) -->
   </template>
 </LoCha>
 ```
@@ -134,13 +119,12 @@ import type {
   ApiLinkGroups,
   ApiResponse,
   Changeset,
-  ChangesetsSlotProps,
+  GroupSlotProps,
   IFeature,
-  LinkMetadataSlotProps,
+  ObjectDetailSlotProps,
   Reason,
   ReasonGeom,
   ReasonTags,
-  TagsDiffSlotProps,
 } from '@teritorio/openstreetmap-logical-history-component'
 ```
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,15 +69,8 @@ function getLinks(feature: IFeature, index: number): ApiLink[] {
   return links.filter(l => l.before === feature.id || l.after === feature.id)
 }
 
-function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined {
-  return geojson.value?.features.find(f => f.id === link.before)?.properties
-}
-
-function getTagsTitle(link: ApiLink): string {
-  const beforeFeature = geojson.value?.features.find(f => f.id === link.before)
-  if (beforeFeature)
-    return `${beforeFeature.properties.objtype}${beforeFeature.properties.id}-v${beforeFeature.properties.version}`
-  return ''
+function getBeforeFeature(link: ApiLink): IFeature | undefined {
+  return geojson.value?.features.find(f => f.id === link.before)
 }
 
 function handleSubmit(data: FormData) {
@@ -127,17 +120,19 @@ function handleSubmit(data: FormData) {
       <template #object-detail="{ feature, index }">
         <template v-for="(link, i) in getLinks(feature, index)" :key="i">
           <template v-if="feature.properties.is_after">
-            <div class="infos">
-              <span v-if="getTagsTitle(link)" class="title">🔗 {{ getTagsTitle(link) }}</span>
-              <span v-if="getBeforeProperties(link)" class="date">📅 {{ feature.properties.created }}</span>
-            </div>
-            <LoChaReason :reason="link.conflation_reason" />
-            <LoChaDiff
-              v-if="!feature.properties.deleted"
-              :diff="link.diff_tags"
-              :dst="feature.properties"
-              :src="getBeforeProperties(link)"
-            />
+            <template v-for="(before, _) in [getBeforeFeature(link)]" :key="_">
+              <div class="infos">
+                <span v-if="before" class="title">🔗 {{ `${before.properties.objtype}${before.properties.id}-v${before.properties.version}` }}</span>
+                <span v-if="before" class="date">📅 {{ feature.properties.created }}</span>
+              </div>
+              <LoChaReason :reason="link.conflation_reason" />
+              <LoChaDiff
+                v-if="!feature.properties.deleted"
+                :diff="link.diff_tags"
+                :dst="feature.properties"
+                :src="before?.properties"
+              />
+            </template>
           </template>
           <template v-else>
             <LoChaDiff

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FormData, LoChaData } from '@/types'
+import type { ApiLink, FormData, IFeature, LoChaData } from '@/types'
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import LoCha from '@/components/LoCha/LoCha.vue'
@@ -56,6 +56,30 @@ async function fetchData(query: Record<string, string | undefined>) {
   geojson.value = await $api.fetchData(query)
 }
 
+function getLinks(feature: IFeature, index: number): ApiLink[] {
+  if (!geojson.value)
+    return []
+
+  const links = geojson.value.metadata.links[index]
+  if (feature.properties.is_before) {
+    const link = links.find(l => l.before === feature.id || l.after === feature.id)
+    return link ? [link] : []
+  }
+
+  return links.filter(l => l.before === feature.id || l.after === feature.id)
+}
+
+function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined {
+  return geojson.value?.features.find(f => f.id === link.before)?.properties
+}
+
+function getTagsTitle(link: ApiLink): string {
+  const beforeFeature = geojson.value?.features.find(f => f.id === link.before)
+  if (beforeFeature)
+    return `${beforeFeature.properties.objtype}${beforeFeature.properties.id}-v${beforeFeature.properties.version}`
+  return ''
+}
+
 function handleSubmit(data: FormData) {
   if (!data.dateStart)
     throw new Error('Missing start date.')
@@ -100,18 +124,28 @@ function handleSubmit(data: FormData) {
       <h2>After : {{ dateTo }}</h2>
     </div>
     <LoCha id="demo" :data="geojson" :reason-collapsed="false">
-      <template #tags-diff="{ title, date, diff, dst, src, reason }">
-        <div class="infos">
-          <span v-if="title" class="title">🔗 {{ title }}</span>
-          <span v-if="dst?.is_after && src" class="date">📅 {{ date }}</span>
-        </div>
-        <LoChaReason v-if="dst" :reason="reason" />
-        <LoChaDiff
-          v-if="!dst?.deleted"
-          :diff="diff"
-          :dst="dst"
-          :src="src"
-        />
+      <template #object-detail="{ feature, index }">
+        <template v-for="(link, i) in getLinks(feature, index)" :key="i">
+          <template v-if="feature.properties.is_after">
+            <div class="infos">
+              <span v-if="getTagsTitle(link)" class="title">🔗 {{ getTagsTitle(link) }}</span>
+              <span v-if="getBeforeProperties(link)" class="date">📅 {{ feature.properties.created }}</span>
+            </div>
+            <LoChaReason :reason="link.conflation_reason" />
+            <LoChaDiff
+              v-if="!feature.properties.deleted"
+              :diff="link.diff_tags"
+              :dst="feature.properties"
+              :src="getBeforeProperties(link)"
+            />
+          </template>
+          <template v-else>
+            <LoChaDiff
+              :diff="link.diff_tags"
+              :src="feature.properties"
+            />
+          </template>
+        </template>
       </template>
     </LoCha>
   </main>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ChangesetsSlotProps, LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
+import type { GroupSlotProps, LoChaData, ObjectDetailSlotProps } from '@/types'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -18,10 +18,10 @@ const props = withDefaults(defineProps<{
 })
 
 defineSlots<{
-  'tags-diff': (props: TagsDiffSlotProps) => void
-  'link-metadata': (props: LinkMetadataSlotProps) => void
-  'group-actions': (props: LinkMetadataSlotProps) => void
-  'changesets'?: (props: ChangesetsSlotProps) => void
+  'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-center'?: (props: GroupSlotProps) => void
+  'header-end'?: (props: GroupSlotProps) => void
+  'content-start'?: (props: GroupSlotProps) => void
 }>()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
@@ -49,17 +49,17 @@ watch(() => props.data, (newValue) => {
       ⚠️ No data
     </p>
     <LoChaGroupList v-else :hash="hash">
-      <template #tags-diff="slotProps">
-        <slot name="tags-diff" v-bind="slotProps" />
+      <template v-if="$slots['object-detail']" #object-detail="slotProps">
+        <slot name="object-detail" v-bind="slotProps" />
       </template>
-      <template #link-metadata="slotProps">
-        <slot name="link-metadata" v-bind="slotProps" />
+      <template v-if="$slots['header-center']" #header-center="slotProps">
+        <slot name="header-center" v-bind="slotProps" />
       </template>
-      <template #group-actions="slotProps">
-        <slot name="group-actions" v-bind="slotProps" />
+      <template v-if="$slots['header-end']" #header-end="slotProps">
+        <slot name="header-end" v-bind="slotProps" />
       </template>
-      <template v-if="$slots.changesets" #changesets="slotProps">
-        <slot name="changesets" v-bind="slotProps" />
+      <template v-if="$slots['content-start']" #content-start="slotProps">
+        <slot name="content-start" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, ChangesetsSlotProps, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
+import type { GroupSlotProps, LoChaGroup, ObjectDetailSlotProps } from '@/types'
 import { computed, inject, useSlots } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
@@ -17,14 +17,14 @@ defineEmits<{
 }>()
 
 defineSlots<{
-  'tags-diff': (props: TagsDiffSlotProps) => void
-  'link-metadata': (props: LinkMetadataSlotProps) => void
-  'group-actions'?: (props: LinkMetadataSlotProps) => void
-  'changesets'?: (props: ChangesetsSlotProps) => void
+  'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-center'?: (props: GroupSlotProps) => void
+  'header-end'?: (props: GroupSlotProps) => void
+  'content-start'?: (props: GroupSlotProps) => void
 }>()
 
 const runtimeSlots = useSlots()
-const gridColumns = computed(() => runtimeSlots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
+const gridColumns = computed(() => runtimeSlots['content-start'] ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -32,22 +32,6 @@ const { loCha, getBeforeFeatures, getAfterFeatures } = inject(LOCHA_KEY)!
 
 if (!loCha.value)
   throw new Error('LoCha is empty.')
-
-function getDiffs(
-  feature: IFeature,
-  index: number,
-): ApiLink[] | undefined {
-  if (feature.properties.is_before) {
-    const link = loCha.value!.metadata.links[index].find(link => link.before === feature.id || link.after === feature.id)
-    return link && [link]
-  }
-
-  return loCha.value!.metadata.links[index].filter(link => link.before === feature.id || link.after === feature.id)
-}
-
-function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined {
-  return loCha.value!.features.find(feature => feature.id === link!.before)?.properties
-}
 
 const groupName = computed(() => {
   const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
@@ -61,17 +45,6 @@ const groupName = computed(() => {
 
   return `${beforeLabel} → ${afterLabel}`
 })
-
-function getTagsTitle(link: ApiLink): string {
-  let title = ''
-
-  const beforeFeature = loCha.value!.features.find(feature => feature.id === link!.before)
-
-  if (beforeFeature)
-    title = `${beforeFeature.properties.objtype}${beforeFeature.properties.id}-v${beforeFeature.properties.version}`
-
-  return title
-}
 </script>
 
 <template>
@@ -81,16 +54,16 @@ function getTagsTitle(link: ApiLink): string {
       <h3 class="group-name">
         {{ groupName }}
       </h3>
-      <div class="link-metadata">
-        <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
+      <div class="header-center">
+        <slot name="header-center" :index="index" />
       </div>
-      <div v-if="$slots['group-actions']" class="group-actions">
-        <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
+      <div v-if="$slots['header-end']" class="header-end">
+        <slot name="header-end" :index="index" />
       </div>
     </div>
     <div class="group-content">
-      <div v-if="$slots.changesets" class="changesets-list">
-        <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
+      <div v-if="$slots['content-start']" class="content-start">
+        <slot name="content-start" :index="index" />
       </div>
       <div class="before-list">
         <ul>
@@ -99,16 +72,8 @@ function getTagsTitle(link: ApiLink): string {
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
-              <template #tags-diff>
-                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                  <slot
-                    name="tags-diff"
-                    :date="feature.properties.created"
-                    :diff="link.diff_tags"
-                    :src="feature.properties"
-                    :reason="link.conflation_reason"
-                  />
-                </template>
+              <template v-if="$slots['object-detail']" #object-detail>
+                <slot name="object-detail" :feature="feature" :index="index" />
               </template>
             </LoChaObject>
           </li>
@@ -121,18 +86,8 @@ function getTagsTitle(link: ApiLink): string {
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
-              <template #tags-diff>
-                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                  <slot
-                    name="tags-diff"
-                    :date="feature.properties.created"
-                    :title="getTagsTitle(link)"
-                    :diff="link.diff_tags"
-                    :reason="link.conflation_reason"
-                    :dst="feature.properties"
-                    :src="getBeforeProperties(link)"
-                  />
-                </template>
+              <template v-if="$slots['object-detail']" #object-detail>
+                <slot name="object-detail" :feature="feature" :index="index" />
               </template>
             </LoChaObject>
           </li>
@@ -179,7 +134,7 @@ function getTagsTitle(link: ApiLink): string {
   padding: 0.25rem;
 }
 
-.link-metadata {
+.header-center {
   min-width: 0;
   display: flex;
   flex-wrap: wrap;

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -24,7 +24,7 @@ defineSlots<{
 }>()
 
 const runtimeSlots = useSlots()
-const gridColumns = computed(() => runtimeSlots['content-start'] ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
+const gridColumns = computed(() => runtimeSlots['content-start'] ? 'repeat(4, minmax(0, 1fr))' : 'repeat(3, minmax(0, 1fr))')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ChangesetsSlotProps, LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
+import type { GroupSlotProps, ObjectDetailSlotProps } from '@/types'
 import { inject, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors } from '@/composables/useLoCha'
@@ -11,10 +11,10 @@ const props = defineProps<{
 }>()
 
 defineSlots<{
-  'tags-diff': (props: TagsDiffSlotProps) => void
-  'link-metadata': (props: LinkMetadataSlotProps) => void
-  'group-actions': (props: LinkMetadataSlotProps) => void
-  'changesets'?: (props: ChangesetsSlotProps) => void
+  'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-center'?: (props: GroupSlotProps) => void
+  'header-end'?: (props: GroupSlotProps) => void
+  'content-start'?: (props: GroupSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!
@@ -59,17 +59,17 @@ onMounted(() => {
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()" @navigate="navigateToHash">
-          <template #tags-diff="slotProps">
-            <slot name="tags-diff" v-bind="slotProps" />
+          <template v-if="$slots['object-detail']" #object-detail="slotProps">
+            <slot name="object-detail" v-bind="slotProps" />
           </template>
-          <template #link-metadata="slotProps">
-            <slot name="link-metadata" v-bind="slotProps" />
+          <template v-if="$slots['header-center']" #header-center="slotProps">
+            <slot name="header-center" v-bind="slotProps" />
           </template>
-          <template #group-actions="slotProps">
-            <slot name="group-actions" v-bind="slotProps" />
+          <template v-if="$slots['header-end']" #header-end="slotProps">
+            <slot name="header-end" v-bind="slotProps" />
           </template>
-          <template v-if="$slots.changesets" #changesets="slotProps">
-            <slot name="changesets" v-bind="slotProps" />
+          <template v-if="$slots['content-start']" #content-start="slotProps">
+            <slot name="content-start" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
   josmTarget?: string
 }>()
 
-defineSlots<{ 'tags-diff': () => void }>()
+defineSlots<{ 'object-detail'?: () => void }>()
 
 const { getStatus } = inject(LOCHA_KEY)!
 
@@ -108,7 +108,7 @@ const color = computed(() => loChaColors[status.value])
         👤{{ feature.properties.username }}
       </a>
     </header>
-    <slot name="tags-diff" />
+    <slot name="object-detail" />
   </article>
 </template>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,13 @@ export type {
   ApiLink,
   ApiLinkGroups,
   Changeset,
-  ChangesetsSlotProps,
+  GroupSlotProps,
   IFeature,
-  LinkMetadataSlotProps,
   LoChaData,
+  ObjectDetailSlotProps,
   Reason,
   ReasonGeom,
   ReasonTags,
-  TagsDiffSlotProps,
 } from './types'
 
 export { scrollToSection, type ScrollToSectionOptions } from './utils/scrollToSection'

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { Actions, ApiLink, Changeset, IFeature, LoChaData, Reason } from './api'
+import type { IFeature, LoChaData } from './api'
 
 /**
  * The possible statuses for features in the system.
@@ -29,30 +29,17 @@ export type Color = {
 export type LoChaGroup = IFeature[]
 
 /**
- * Props passed through the `tags-diff` slot across the LoCha component hierarchy.
+ * Props passed through the `object-detail` slot (rendered once per feature inside each object card).
  */
-export interface TagsDiffSlotProps {
-  date: string
-  diff: Actions | undefined
-  src?: IFeature['properties']
-  dst?: IFeature['properties']
-  reason: Reason
-  title?: string
-}
-
-/**
- * Props passed through the `link-metadata` slot across the LoCha component hierarchy.
- */
-export interface LinkMetadataSlotProps {
-  links: ApiLink[]
+export interface ObjectDetailSlotProps {
+  feature: IFeature
   index: number
 }
 
 /**
- * Props passed through the `changesets` slot across the LoCha component hierarchy.
+ * Props passed through group-level slots (`header-center`, `header-end`, `content-start`).
  */
-export interface ChangesetsSlotProps {
-  changesets: Changeset[]
+export interface GroupSlotProps {
   index: number
 }
 


### PR DESCRIPTION
## Summary

Closes #134

- Rename all slots to position-based, domain-agnostic names: `tags-diff` → `object-detail`, `link-metadata` → `header-center`, `group-actions` → `header-end`, `changesets` → `content-start`
- Simplify slot props to generic contextual data (`{ feature, index }` for object slots, `{ index }` for group slots)
- Remove domain-specific pre-computation logic from `LoChaGroup.vue` (`getDiffs`, `getBeforeProperties`, `getTagsTitle`)
- Replace `TagsDiffSlotProps`, `LinkMetadataSlotProps`, `ChangesetsSlotProps` with `ObjectDetailSlotProps` and `GroupSlotProps`
- Update demo `App.vue` to perform its own data lookups as a consumer example

## BREAKING CHANGE

All slot names and their props have changed. Consumers must update their slot templates and handle data lookups themselves.

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `vue-tsc --noEmit` passes
- [ ] Manual verification: run `yarn dev` and confirm the demo renders correctly with the new slot structure