### PR TITLE
Improve color palette accessibility and gray scale consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ coverage/
 *.log
 *.cache/
 
+# Claude Code
+.claude/
+
 # Miscellaneous
 *.tmp
 *.bak

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ const data = ref<ApiResponse>()
 
 ### Props
 
-| Prop              | Type          | Default     | Description                                                   |
-| ----------------- | ------------- | ----------- | ------------------------------------------------------------- |
-| `data`            | `ApiResponse` | `undefined` | The API response containing features and metadata to display. |
-| `reasonCollapsed` | `boolean`     | `true`      | Whether conflation reason details are collapsed by default.   |
+| Prop              | Type          | Default     | Description                                                                    |
+| ----------------- | ------------- | ----------- | ------------------------------------------------------------------------------ |
+| `id`              | `string`      | —           | **Required.** A unique, deterministic identifier used to build anchor targets. |
+| `data`            | `ApiResponse` | `undefined` | The API response containing features and metadata to display.                  |
+| `reasonCollapsed` | `boolean`     | `true`      | Whether conflation reason details are collapsed by default.                    |
 
 ### Slots
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ Additional slot props on "after" features only:
 | `title` | `string`                 | A label for the tag diff.               |
 | `dst`   | `IFeature['properties']` | Destination (after) feature properties. |
 
+#### `#link-metadata`
+
+A scoped slot rendered once per group in the full-width header area, allowing custom rendering of link metadata.
+
+| Prop    | Type        | Description                                    |
+| ------- | ----------- | ---------------------------------------------- |
+| `index` | `number`    | The group index.                               |
+| `links` | `ApiLink[]` | The array of links associated with this group. |
+
+#### `#group-actions`
+
+A scoped slot rendered once per group, positioned to the right of the link metadata header. Useful for injecting per-group action buttons (e.g. accept/reject validation).
+
+| Prop    | Type        | Description                                    |
+| ------- | ----------- | ---------------------------------------------- |
+| `index` | `number`    | The group index.                               |
+| `links` | `ApiLink[]` | The array of links associated with this group. |
+
+Example usage:
+
+```vue
+<LoCha :data="data" map-style-url="...">
+  <template #group-actions="{ index, links }">
+    <button @click="acceptGroup(index)">Accept</button>
+  </template>
+</LoCha>
+```
+
 ### Types
 
 All consumer-facing types are exported from the package entry point:

--- a/README.md
+++ b/README.md
@@ -93,12 +93,30 @@ A scoped slot rendered once per group, positioned to the right of the link metad
 | `index` | `number`    | The group index.                               |
 | `links` | `ApiLink[]` | The array of links associated with this group. |
 
+#### `#changesets`
+
+A scoped slot rendered once per group as the first column (before the "before" column). When provided, the grid switches from 3 to 4 columns. When omitted, the layout remains unchanged at 3 columns.
+
+| Prop         | Type          | Description                                         |
+| ------------ | ------------- | --------------------------------------------------- |
+| `index`      | `number`      | The group index.                                    |
+| `changesets` | `Changeset[]` | The full array of changesets from the API response. |
+
+> **Note:** The `changesets` array contains all changesets from the response, not filtered per group. The consumer is responsible for filtering relevant changesets (e.g. by matching `changeset_id` from feature properties against `Changeset.id`).
+
 Example usage:
 
 ```vue
 <LoCha :data="data" map-style-url="...">
   <template #group-actions="{ index, links }">
     <button @click="acceptGroup(index)">Accept</button>
+  </template>
+  <template #changesets="{ changesets, index }">
+    <ul>
+      <li v-for="cs in changesets" :key="cs.id">
+        {{ cs.user }} — {{ cs.tags?.comment }}
+      </li>
+    </ul>
   </template>
 </LoCha>
 ```
@@ -115,10 +133,14 @@ import type {
   ApiLink,
   ApiLinkGroups,
   ApiResponse,
+  Changeset,
+  ChangesetsSlotProps,
   IFeature,
+  LinkMetadataSlotProps,
   Reason,
   ReasonGeom,
   ReasonTags,
+  TagsDiffSlotProps,
 } from '@teritorio/openstreetmap-logical-history-component'
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,4 @@ export default antfu({
   formatters: true,
   typescript: true,
   vue: true,
-  ignores: ['.claude/worktrees/**'],
 })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,4 +5,5 @@ export default antfu({
   formatters: true,
   typescript: true,
   vue: true,
+  ignores: ['.claude/worktrees/**'],
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@sentry/vite-plugin": "^5.1.1",
+    "@types/node": "^25.6.0",
     "@types/underscore": "^1.13.0",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/coverage-v8": "^4.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -130,7 +130,9 @@ main {
   grid-row: 1;
   display: flex;
   gap: 1rem;
-  padding: 1rem 1rem 0;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(to bottom, #e8e8ea, #f0f0f2);
+  border-bottom: 1px solid #d0d0d2;
 }
 
 aside {
@@ -140,6 +142,10 @@ aside {
 .locha-header h2 {
   flex: 1;
   text-align: center;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333333;
 }
 
 .locha {

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@ function handleSubmit(data: FormData) {
       <h2>Before : {{ dateFrom }}</h2>
       <h2>After : {{ dateTo }}</h2>
     </div>
-    <LoCha :data="geojson" :reason-collapsed="false">
+    <LoCha id="demo" :data="geojson" :reason-collapsed="false">
       <template #tags-diff="{ title, date, diff, dst, src, reason }">
         <div class="infos">
           <span v-if="title" class="title">🔗 {{ title }}</span>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
+import type { ChangesetsSlotProps, LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
 import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
@@ -21,6 +21,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
@@ -56,6 +57,9 @@ watch(() => props.data, (newValue) => {
       </template>
       <template #group-actions="slotProps">
         <slot name="group-actions" v-bind="slotProps" />
+      </template>
+      <template #changesets="slotProps">
+        <slot name="changesets" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -19,6 +19,7 @@ const props = withDefaults(defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const instanceId = useId()
@@ -53,6 +54,9 @@ watch(() => props.data, (newValue) => {
       </template>
       <template #link-metadata="slotProps">
         <slot name="link-metadata" v-bind="slotProps" />
+      </template>
+      <template #group-actions="slotProps">
+        <slot name="group-actions" v-bind="slotProps" />
       </template>
     </LoChaGroupList>
   </section>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -21,7 +21,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
-  'changesets': (props: ChangesetsSlotProps) => void
+  'changesets'?: (props: ChangesetsSlotProps) => void
 }>()
 
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -69,7 +69,6 @@ watch(() => props.data, (newValue) => {
 .locha {
   display: flex;
   flex-direction: column;
-  background-color: #f4f4f4;
   height: inherit;
 }
 

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import type { LinkMetadataSlotProps, LoChaData, TagsDiffSlotProps } from '@/types'
-import { provide, useId, watch } from 'vue'
+import { provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY, MAP_STYLE_URL_KEY, REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 
 const props = withDefaults(defineProps<{
+  id: string
   data?: LoChaData
   mapStyleUrl?: string
   reasonCollapsed?: boolean
@@ -22,10 +23,8 @@ defineSlots<{
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
-const instanceId = useId()
-
 provide(REASON_COLLAPSED_KEY, props.reasonCollapsed)
-provide(LOCHA_INSTANCE_ID_KEY, instanceId)
+provide(LOCHA_INSTANCE_ID_KEY, props.id)
 provide(MAP_STYLE_URL_KEY, props.mapStyleUrl)
 
 const loChaInstance = useLoCha()

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -58,7 +58,7 @@ watch(() => props.data, (newValue) => {
       <template #group-actions="slotProps">
         <slot name="group-actions" v-bind="slotProps" />
       </template>
-      <template #changesets="slotProps">
+      <template v-if="$slots.changesets" #changesets="slotProps">
         <slot name="changesets" v-bind="slotProps" />
       </template>
     </LoChaGroupList>

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -70,6 +70,7 @@ watch(() => props.data, (newValue) => {
   display: flex;
   flex-direction: column;
   height: inherit;
+  padding: 1rem;
 }
 
 .locha-group-list {

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -197,7 +197,7 @@ thead th {
 table,
 th,
 td {
-  border: 1px solid #000000;
+  border: 1px solid #4a4a4a;
   border-collapse: collapse;
   padding: 0.15rem;
 }
@@ -232,7 +232,7 @@ td {
 }
 
 .no_changes {
-  background-color: #f4f4f5;
+  background-color: #ebebee;
 }
 
 thead th > div {

--- a/src/components/LoCha/LoChaDiffTag.vue
+++ b/src/components/LoCha/LoChaDiffTag.vue
@@ -46,7 +46,7 @@ defineProps<{
 }
 
 .no_changes {
-  background-color: #f4f4f5;
+  background-color: #ebebee;
 }
 
 .attribute-changed {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -19,8 +19,8 @@ defineEmits<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
-  'group-actions': (props: LinkMetadataSlotProps) => void
-  'changesets': (props: ChangesetsSlotProps) => void
+  'group-actions'?: (props: LinkMetadataSlotProps) => void
+  'changesets'?: (props: ChangesetsSlotProps) => void
 }>()
 
 const runtimeSlots = useSlots()

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -155,6 +155,12 @@ function getTagsTitle(link: ApiLink): string {
   gap: 0.5rem;
 }
 
+.group-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
 .anchor-button {
   border: 2px solid #cecece;
   background-color: #ffffff;

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ApiLink, ChangesetsSlotProps, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
-import { computed, inject } from 'vue'
+import { computed, inject, useSlots } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
@@ -16,14 +16,15 @@ defineEmits<{
   navigate: [hash: string]
 }>()
 
-const slots = defineSlots<{
+defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
   'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
-const gridColumns = computed(() => slots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
+const runtimeSlots = useSlots()
+const gridColumns = computed(() => runtimeSlots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ApiLink, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
+import type { ApiLink, ChangesetsSlotProps, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
 import { computed, inject } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
@@ -16,14 +16,16 @@ defineEmits<{
   navigate: [hash: string]
 }>()
 
-defineSlots<{
+const slots = defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 const groupBackgroundPalette = ['#e0e0e2', '#e8e8ea', '#f0f0f2', '#f8f8fa']
 const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
+const gridColumns = computed(() => slots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -87,6 +89,9 @@ function getTagsTitle(link: ApiLink): string {
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>
+    <div v-if="slots.changesets" class="changesets-list">
+      <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
+    </div>
     <div class="before-list">
       <ul>
         <li
@@ -140,7 +145,7 @@ function getTagsTitle(link: ApiLink): string {
 <style lang="css" scoped>
 .locha-group {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: v-bind(gridColumns);
   gap: 1rem;
   border: 2px solid #cecece;
   background-color: v-bind(groupBackground);
@@ -176,16 +181,7 @@ function getTagsTitle(link: ApiLink): string {
   gap: 0.3em;
 }
 
-.before-list {
-  grid-column: 1;
-}
-
-.after-list {
-  grid-column: 2;
-}
-
 .v-map {
-  grid-column: 3;
   border: 1px solid #000000;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -87,70 +87,75 @@ function getTagsTitle(link: ApiLink): string {
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>
-    <div v-if="$slots.changesets" class="changesets-list">
-      <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
-    </div>
-    <div class="before-list">
-      <ul>
-        <li
-          v-for="feature in getBeforeFeatures(features)"
-          :key="feature.id"
-        >
-          <LoChaObject :feature="feature" :josm-target="josmTarget">
-            <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                <slot
-                  name="tags-diff"
-                  :date="feature.properties.created"
-                  :diff="link.diff_tags"
-                  :src="feature.properties"
-                  :reason="link.conflation_reason"
-                />
+    <div class="group-content">
+      <div v-if="$slots.changesets" class="changesets-list">
+        <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
+      </div>
+      <div class="before-list">
+        <ul>
+          <li
+            v-for="feature in getBeforeFeatures(features)"
+            :key="feature.id"
+          >
+            <LoChaObject :feature="feature" :josm-target="josmTarget">
+              <template #tags-diff>
+                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                  <slot
+                    name="tags-diff"
+                    :date="feature.properties.created"
+                    :diff="link.diff_tags"
+                    :src="feature.properties"
+                    :reason="link.conflation_reason"
+                  />
+                </template>
               </template>
-            </template>
-          </LoChaObject>
-        </li>
-      </ul>
-    </div>
-    <div class="after-list">
-      <ul>
-        <li
-          v-for="feature in getAfterFeatures(features)"
-          :key="feature.id"
-        >
-          <LoChaObject :feature="feature" :josm-target="josmTarget">
-            <template #tags-diff>
-              <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
-                <slot
-                  name="tags-diff"
-                  :date="feature.properties.created"
-                  :title="getTagsTitle(link)"
-                  :diff="link.diff_tags"
-                  :reason="link.conflation_reason"
-                  :dst="feature.properties"
-                  :src="getBeforeProperties(link)"
-                />
+            </LoChaObject>
+          </li>
+        </ul>
+      </div>
+      <div class="after-list">
+        <ul>
+          <li
+            v-for="feature in getAfterFeatures(features)"
+            :key="feature.id"
+          >
+            <LoChaObject :feature="feature" :josm-target="josmTarget">
+              <template #tags-diff>
+                <template v-for="(link, i) in getDiffs(feature, index)" :key="i">
+                  <slot
+                    name="tags-diff"
+                    :date="feature.properties.created"
+                    :title="getTagsTitle(link)"
+                    :diff="link.diff_tags"
+                    :reason="link.conflation_reason"
+                    :dst="feature.properties"
+                    :src="getBeforeProperties(link)"
+                  />
+                </template>
               </template>
-            </template>
-          </LoChaObject>
-        </li>
-      </ul>
+            </LoChaObject>
+          </li>
+        </ul>
+      </div>
+      <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />
     </div>
-    <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />
   </div>
 </template>
 
 <style lang="css" scoped>
 .locha-group {
-  display: grid;
-  grid-template-columns: v-bind(gridColumns);
-  gap: 1rem;
   border: 2px solid #cecece;
   background-color: #ffffff;
 }
 
+.group-content {
+  display: grid;
+  grid-template-columns: v-bind(gridColumns);
+  gap: 1rem;
+  padding: 0.5rem;
+}
+
 .group-header {
-  grid-column: 1 / -1;
   display: grid;
   grid-template-columns: auto auto 1fr auto;
   align-items: center;

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -58,7 +58,7 @@ function getTagsTitle(link: ApiLink): string {
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
-      <div class="group-actions">
+      <div v-if="$slots['group-actions']" class="group-actions">
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -161,6 +161,7 @@ function getTagsTitle(link: ApiLink): string {
 
 .v-map {
   grid-column: 3;
+  border: 1px solid #000000;
 }
 
 ul {
@@ -168,5 +169,6 @@ ul {
   display: flex;
   flex-direction: column;
   gap: 0.5em;
+  padding: 0;
 }
 </style>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -147,7 +147,6 @@ function getTagsTitle(link: ApiLink): string {
   gap: 1rem;
   border: 2px solid #cecece;
   background-color: #ffffff;
-  padding: 8px;
 }
 
 .group-header {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -156,6 +156,9 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
+  background-color: #f0f0f2;
+  padding: 0.5rem;
+  border-bottom: 1px solid #cecece;
 }
 
 .group-name {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ApiLink, IFeature, LinkMetadataSlotProps, LoChaGroup, TagsDiffSlotProps } from '@/types'
-import { inject } from 'vue'
+import { computed, inject } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
@@ -21,6 +21,9 @@ defineSlots<{
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
+
+const groupBackgroundPalette = ['#ededee', '#f0f0f1', '#f4f4f6', '#fafbfd']
+const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -124,7 +127,7 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: repeat(3, 1fr);
   gap: 1rem;
   border: 2px solid #cecece;
-  background-color: #ffffff;
+  background-color: v-bind(groupBackground);
   padding: 8px;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -89,7 +89,7 @@ function getTagsTitle(link: ApiLink): string {
         <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
     </div>
-    <div v-if="slots.changesets" class="changesets-list">
+    <div v-if="$slots.changesets" class="changesets-list">
       <slot name="changesets" :changesets="loCha!.metadata.changesets" :index="index" />
     </div>
     <div class="before-list">

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -160,16 +160,15 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
-  background: linear-gradient(to bottom, #e8e8ea, #f0f0f2);
-  padding: 0.75rem;
-  border-bottom: 1px solid #d0d0d2;
+  background-color: #f0f0f2;
+  padding: 0.5rem;
+  border-bottom: 1px solid #cecece;
 }
 
 .group-name {
   margin: 0;
   font-size: 1rem;
-  font-weight: 600;
-  color: #333333;
+  font-weight: 500;
 }
 
 .anchor-button {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -130,8 +130,8 @@ function getTagsTitle(link: ApiLink): string {
 
 .group-header {
   grid-column: 1 / -1;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
 }
@@ -144,8 +144,11 @@ function getTagsTitle(link: ApiLink): string {
 }
 
 .link-metadata {
-  flex: 1;
   min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  place-content: center;
+  gap: 0.3em;
 }
 
 .before-list {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -145,7 +145,7 @@ function getTagsTitle(link: ApiLink): string {
 
 <style lang="css" scoped>
 .locha-group {
-  border: 2px solid #cecece;
+  border: 2px solid #c8c8cc;
   background-color: #ffffff;
 }
 
@@ -161,9 +161,9 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
-  background-color: #f0f0f2;
+  background-color: #e8e8ec;
   padding: 0.5rem;
-  border-bottom: 1px solid #cecece;
+  border-bottom: 1px solid #c8c8cc;
 }
 
 .group-name {
@@ -173,7 +173,7 @@ function getTagsTitle(link: ApiLink): string {
 }
 
 .anchor-button {
-  border: 2px solid #cecece;
+  border: 2px solid #c8c8cc;
   background-color: #ffffff;
   text-decoration: none;
   padding: 0.25rem;
@@ -188,7 +188,7 @@ function getTagsTitle(link: ApiLink): string {
 }
 
 .v-map {
-  border: 1px solid #000000;
+  border: 1px solid #4a4a4a;
 }
 
 ul {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -132,7 +132,7 @@ function getTagsTitle(link: ApiLink): string {
   grid-column: 1 / -1;
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.5rem;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -48,6 +48,19 @@ function getBeforeProperties(link: ApiLink): IFeature['properties'] | undefined 
   return loCha.value!.features.find(feature => feature.id === link!.before)?.properties
 }
 
+const groupName = computed(() => {
+  const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+  const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+
+  const beforeLabel = beforeNames.length > 0 ? beforeNames.join(', ') : '(unnamed)'
+  const afterLabel = afterNames.length > 0 ? afterNames.join(', ') : '(unnamed)'
+
+  if (beforeLabel === afterLabel)
+    return beforeLabel
+
+  return `${beforeLabel} → ${afterLabel}`
+})
+
 function getTagsTitle(link: ApiLink): string {
   let title = ''
 
@@ -64,6 +77,9 @@ function getTagsTitle(link: ApiLink): string {
   <div :id="id" class="locha-group">
     <div class="group-header">
       <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
+      <h3 class="group-name">
+        {{ groupName }}
+      </h3>
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
@@ -134,7 +150,7 @@ function getTagsTitle(link: ApiLink): string {
 .group-header {
   grid-column: 1 / -1;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
 }

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -23,8 +23,6 @@ const slots = defineSlots<{
   'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
-const groupBackgroundPalette = ['#e0e0e2', '#e8e8ea', '#f0f0f2', '#f8f8fa']
-const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
 const gridColumns = computed(() => slots.changesets ? 'repeat(4, 1fr)' : 'repeat(3, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
@@ -148,7 +146,7 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: v-bind(gridColumns);
   gap: 1rem;
   border: 2px solid #cecece;
-  background-color: v-bind(groupBackground);
+  background-color: #ffffff;
   padding: 8px;
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
@@ -53,8 +54,13 @@ function getTagsTitle(link: ApiLink): string {
 
 <template>
   <div class="locha-group">
-    <div class="link-metadata">
-      <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
+    <div class="group-header">
+      <div class="link-metadata">
+        <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
+      </div>
+      <div class="group-actions">
+        <slot name="group-actions" :links="loCha!.metadata.links[index]" :index="index" />
+      </div>
     </div>
     <div class="before-list">
       <ul>
@@ -116,8 +122,17 @@ function getTagsTitle(link: ApiLink): string {
   padding: 8px;
 }
 
-.link-metadata {
+.group-header {
   grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.link-metadata {
+  flex: 1;
+  min-width: 0;
 }
 
 .before-list {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -160,15 +160,16 @@ function getTagsTitle(link: ApiLink): string {
   grid-template-columns: auto auto 1fr auto;
   align-items: center;
   gap: 0.5rem;
-  background-color: #f0f0f2;
-  padding: 0.5rem;
-  border-bottom: 1px solid #cecece;
+  background: linear-gradient(to bottom, #e8e8ea, #f0f0f2);
+  padding: 0.75rem;
+  border-bottom: 1px solid #d0d0d2;
 }
 
 .group-name {
   margin: 0;
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: 600;
+  color: #333333;
 }
 
 .anchor-button {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -22,7 +22,7 @@ defineSlots<{
   'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
-const groupBackgroundPalette = ['#ededee', '#f0f0f1', '#f4f4f6', '#fafbfd']
+const groupBackgroundPalette = ['#e0e0e2', '#e8e8ea', '#f0f0f2', '#f8f8fa']
 const groupBackground = computed(() => groupBackgroundPalette[props.index % groupBackgroundPalette.length])
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -6,9 +6,14 @@ import VMap from '@/components/VMap.vue'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
 
 const props = defineProps<{
+  id: string
   index: number
   features: LoChaGroup
   josmTarget?: string
+}>()
+
+defineEmits<{
+  navigate: [hash: string]
 }>()
 
 defineSlots<{
@@ -53,8 +58,9 @@ function getTagsTitle(link: ApiLink): string {
 </script>
 
 <template>
-  <div class="locha-group">
+  <div :id="id" class="locha-group">
     <div class="group-header">
+      <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
       <div class="link-metadata">
         <slot name="link-metadata" :links="loCha!.metadata.links[index]" :index="index" />
       </div>
@@ -128,6 +134,13 @@ function getTagsTitle(link: ApiLink): string {
   justify-content: space-between;
   align-items: flex-start;
   gap: 0.5rem;
+}
+
+.anchor-button {
+  border: 2px solid #cecece;
+  background-color: #ffffff;
+  text-decoration: none;
+  padding: 0.25rem;
 }
 
 .link-metadata {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
 defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
+  'group-actions': (props: LinkMetadataSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!
@@ -50,6 +51,9 @@ watch(() => props.hash, (newValue) => {
           </template>
           <template #link-metadata="slotProps">
             <slot name="link-metadata" v-bind="slotProps" />
+          </template>
+          <template #group-actions="slotProps">
+            <slot name="group-actions" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -36,11 +36,6 @@ function navigateToHash(hash: string) {
   nextTick(() => scrollToSection(hash, { container: listRef.value ?? undefined }))
 }
 
-function onAnchorClick(event: Event, index: number) {
-  event.preventDefault()
-  navigateToHash(`#${groupId(index)}`)
-}
-
 watch(() => props.hash, (newValue) => {
   currentHash.value = newValue
   if (newValue) {
@@ -62,7 +57,7 @@ onMounted(() => {
   <div ref="listRef" class="locha-group-list">
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
-        <a class="anchor-button" :href="`#${groupId(index)}`" @click="onAnchorClick($event, index)">🔗</a>
+        <a class="anchor-button" :href="`#${groupId(index)}`" @click.prevent="navigateToHash(`#${groupId(index)}`)">🔗</a>
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -103,10 +103,6 @@ onMounted(() => {
   background-clip: content-box;
 }
 
-.locha-group-list > ul > li {
-  padding: 8px;
-}
-
 .locha-group-list > ul > li.selected .locha-group {
   border-color: v-bind(highlightBorderColor);
 }

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -84,7 +84,8 @@ onMounted(() => {
 
 .locha-group-list > ul {
   overflow-y: auto;
-  margin-right: -12px;
+  margin: 0;
+  padding: 0;
 }
 
 .locha-group-list > ul::-webkit-scrollbar {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
-import { inject, nextTick, ref, useTemplateRef, watch } from 'vue'
+import { inject, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors } from '@/composables/useLoCha'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY } from '@/constants/injectionKeys'
@@ -30,6 +30,17 @@ function josmTargetName(): string {
   return `hidden_josm_target_${instanceId}`
 }
 
+function navigateToHash(hash: string) {
+  currentHash.value = hash
+  history.replaceState(null, '', hash)
+  nextTick(() => scrollToSection(hash, { container: listRef.value ?? undefined }))
+}
+
+function onAnchorClick(event: Event, index: number) {
+  event.preventDefault()
+  navigateToHash(`#${groupId(index)}`)
+}
+
 watch(() => props.hash, (newValue) => {
   currentHash.value = newValue
   if (newValue) {
@@ -38,13 +49,20 @@ watch(() => props.hash, (newValue) => {
 }, {
   immediate: true,
 })
+
+onMounted(() => {
+  const hash = window.location.hash
+  if (hash && !props.hash) {
+    navigateToHash(hash)
+  }
+})
 </script>
 
 <template>
   <div ref="listRef" class="locha-group-list">
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
-        <a class="anchor-button" :href="`#${groupId(index)}`">🔗</a>
+        <a class="anchor-button" :href="`#${groupId(index)}`" @click="onAnchorClick($event, index)">🔗</a>
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -57,8 +57,7 @@ onMounted(() => {
   <div ref="listRef" class="locha-group-list">
     <ul>
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
-        <a class="anchor-button" :href="`#${groupId(index)}`" @click.prevent="navigateToHash(`#${groupId(index)}`)">🔗</a>
-        <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()">
+        <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()" @navigate="navigateToHash">
           <template #tags-diff="slotProps">
             <slot name="tags-diff" v-bind="slotProps" />
           </template>
@@ -100,26 +99,8 @@ onMounted(() => {
   background-clip: content-box;
 }
 
-.locha-group-list > ul > li {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-}
-
 .locha-group-list > ul > li.selected .locha-group {
   border-color: v-bind(highlightBorderColor);
-}
-
-.locha-group-list > ul > li > div {
-  flex: 1;
-  min-width: 0;
-}
-
-.anchor-button {
-  border: 2px solid #cecece;
-  background-color: #ffffff;
-  text-decoration: none;
-  padding: 0.25rem;
 }
 
 ul {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -83,7 +83,6 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem;
 }
 
 .locha-group-list > ul {

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -104,6 +104,10 @@ onMounted(() => {
   background-clip: content-box;
 }
 
+.locha-group-list > ul > li {
+  padding: 8px;
+}
+
 .locha-group-list > ul > li.selected .locha-group {
   border-color: v-bind(highlightBorderColor);
 }

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
+import type { ChangesetsSlotProps, LinkMetadataSlotProps, TagsDiffSlotProps } from '@/types'
 import { inject, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import LoChaGroup from '@/components/LoCha/LoChaGroup.vue'
 import { loChaColors } from '@/composables/useLoCha'
@@ -14,6 +14,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
+  'changesets': (props: ChangesetsSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!
@@ -66,6 +67,9 @@ onMounted(() => {
           </template>
           <template #group-actions="slotProps">
             <slot name="group-actions" v-bind="slotProps" />
+          </template>
+          <template #changesets="slotProps">
+            <slot name="changesets" v-bind="slotProps" />
           </template>
         </LoChaGroup>
       </li>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -14,7 +14,7 @@ defineSlots<{
   'tags-diff': (props: TagsDiffSlotProps) => void
   'link-metadata': (props: LinkMetadataSlotProps) => void
   'group-actions': (props: LinkMetadataSlotProps) => void
-  'changesets': (props: ChangesetsSlotProps) => void
+  'changesets'?: (props: ChangesetsSlotProps) => void
 }>()
 
 const { groups } = inject(LOCHA_KEY)!

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -68,7 +68,7 @@ onMounted(() => {
           <template #group-actions="slotProps">
             <slot name="group-actions" v-bind="slotProps" />
           </template>
-          <template #changesets="slotProps">
+          <template v-if="$slots.changesets" #changesets="slotProps">
             <slot name="changesets" v-bind="slotProps" />
           </template>
         </LoChaGroup>

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -141,13 +141,14 @@ header > a {
 }
 
 .fab-toggle {
-  background: none;
-  border: 1px solid #dcdfe6;
+  background-color: #e8e8ea;
+  border: 1px solid #c0c0c2;
   border-radius: 4px;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
   line-height: 1;
-  padding: 0.15em 0.4em;
+  padding: 0.3em 0.5em;
   color: #333333;
 }
 

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -53,8 +53,8 @@ const color = computed(() => loChaColors[status.value])
           {{ statusContent }}
         </div>
         <div class="fab">
-          <button class="fab-toggle" type="button" title="Actions">
-            ⋯
+          <button class="fab-toggle" type="button" title="Tools">
+            🔧 Tools
           </button>
           <div class="fab-menu">
             <a

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -52,6 +52,44 @@ const color = computed(() => loChaColors[status.value])
         >
           {{ statusContent }}
         </div>
+        <div class="actions">
+          <a
+            :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="Edit in OSM iD"
+            target="_blank"
+            @click.stop
+          >
+            OSM iD
+          </a>
+          <a
+            :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="Edit in JOSM"
+            :target="josmTarget || 'hidden_josm_target'"
+            @click.stop
+          >
+            JOSM
+          </a>
+          <a
+            :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="OSM Deep History"
+            target="_blank"
+            @click.stop
+          >
+            Deep H
+          </a>
+          <a
+            :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
+            type="button"
+            title="OSM History Viewer"
+            target="_blank"
+            @click.stop
+          >
+            OSM H
+          </a>
+        </div>
       </div>
       <p class="date">
         📅 {{ props.feature.properties.created }}
@@ -66,44 +104,6 @@ const color = computed(() => loChaColors[status.value])
       </a>
     </header>
     <slot name="tags-diff" />
-    <div class="actions">
-      <a
-        :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="Edit in OSM iD"
-        target="_blank"
-        @click.stop
-      >
-        OSM iD
-      </a>
-      <a
-        :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="Edit in JOSM"
-        :target="josmTarget || 'hidden_josm_target'"
-        @click.stop
-      >
-        JOSM
-      </a>
-      <a
-        :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="OSM Deep History"
-        target="_blank"
-        @click.stop
-      >
-        Deep H
-      </a>
-      <a
-        :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-        type="button"
-        title="OSM History Viewer"
-        target="_blank"
-        @click.stop
-      >
-        OSM H
-      </a>
-    </div>
   </article>
 </template>
 
@@ -125,11 +125,12 @@ header > a {
 .wrap {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 0.25rem;
 }
 
 .actions {
   display: flex;
+  margin-left: auto;
 }
 
 :deep(.date),

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -53,7 +53,6 @@ const color = computed(() => loChaColors[status.value])
           {{ statusContent }}
         </div>
       </div>
-      <h3>{{ props.feature.properties.tags.name }}</h3>
       <p class="date">
         📅 {{ props.feature.properties.created }}
       </p>
@@ -116,10 +115,6 @@ article {
   flex-direction: column;
   gap: 4px;
   padding: 0.25rem;
-}
-
-h3 {
-  font-weight: 400;
 }
 
 header > a {

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -186,7 +186,7 @@ header > a {
 :deep(.date),
 :deep(.title) {
   font-size: 12px;
-  color: #636366;
+  color: #48484a;
 }
 
 :deep(.infos) {

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -124,7 +124,7 @@ article {
 
 header > a {
   font-size: 0.75em;
-  color: #333333;
+  color: #2c2c2c;
 }
 
 .wrap {
@@ -141,15 +141,15 @@ header > a {
 }
 
 .fab-toggle {
-  background-color: #e8e8ea;
-  border: 1px solid #c0c0c2;
+  background-color: #ffffff;
+  border: 1px solid #a0a0a4;
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
   padding: 0.3em 0.5em;
-  color: #333333;
+  color: #2c2c2c;
 }
 
 .fab-menu {
@@ -160,7 +160,7 @@ header > a {
   z-index: 5;
   flex-direction: column;
   background-color: #ffffff;
-  border: 1px solid #dcdfe6;
+  border: 1px solid #a0a0a4;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   min-width: max-content;
@@ -172,7 +172,7 @@ header > a {
 }
 
 .action-btn {
-  color: #000000;
+  color: #2c2c2c;
   padding: 0.4em 0.75em;
   font-size: 0.75em;
   text-decoration: none;
@@ -180,13 +180,13 @@ header > a {
 }
 
 .action-btn:hover {
-  background-color: #f0f0f2;
+  background-color: #e8e8ec;
 }
 
 :deep(.date),
 :deep(.title) {
   font-size: 12px;
-  color: grey;
+  color: #636366;
 }
 
 :deep(.infos) {

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -55,7 +55,7 @@ const color = computed(() => loChaColors[status.value])
         <div class="actions">
           <a
             :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="Edit in OSM iD"
             target="_blank"
             @click.stop
@@ -64,7 +64,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="Edit in JOSM"
             :target="josmTarget || 'hidden_josm_target'"
             @click.stop
@@ -73,7 +73,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="OSM Deep History"
             target="_blank"
             @click.stop
@@ -82,7 +82,7 @@ const color = computed(() => loChaColors[status.value])
           </a>
           <a
             :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-            type="button"
+            class="action-btn"
             title="OSM History Viewer"
             target="_blank"
             @click.stop
@@ -124,6 +124,7 @@ header > a {
 
 .wrap {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.25rem;
 }
@@ -131,6 +132,7 @@ header > a {
 .actions {
   display: flex;
   margin-left: auto;
+  flex-shrink: 0;
 }
 
 :deep(.date),
@@ -144,7 +146,7 @@ header > a {
   gap: 0.5rem;
 }
 
-[type='button'] {
+.action-btn {
   flex-grow: 1;
   color: #000000;
   padding: 0.5em 1em;

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -52,43 +52,48 @@ const color = computed(() => loChaColors[status.value])
         >
           {{ statusContent }}
         </div>
-        <div class="actions">
-          <a
-            :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            class="action-btn"
-            title="Edit in OSM iD"
-            target="_blank"
-            @click.stop
-          >
-            OSM iD
-          </a>
-          <a
-            :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-            class="action-btn"
-            title="Edit in JOSM"
-            :target="josmTarget || 'hidden_josm_target'"
-            @click.stop
-          >
-            JOSM
-          </a>
-          <a
-            :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-            class="action-btn"
-            title="OSM Deep History"
-            target="_blank"
-            @click.stop
-          >
-            Deep H
-          </a>
-          <a
-            :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-            class="action-btn"
-            title="OSM History Viewer"
-            target="_blank"
-            @click.stop
-          >
-            OSM H
-          </a>
+        <div class="fab">
+          <button class="fab-toggle" type="button" title="Actions">
+            ⋯
+          </button>
+          <div class="fab-menu">
+            <a
+              :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
+              class="action-btn"
+              title="Edit in OSM iD"
+              target="_blank"
+              @click.stop
+            >
+              OSM iD
+            </a>
+            <a
+              :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
+              class="action-btn"
+              title="Edit in JOSM"
+              :target="josmTarget || 'hidden_josm_target'"
+              @click.stop
+            >
+              JOSM
+            </a>
+            <a
+              :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
+              class="action-btn"
+              title="OSM Deep History"
+              target="_blank"
+              @click.stop
+            >
+              Deep H
+            </a>
+            <a
+              :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
+              class="action-btn"
+              title="OSM History Viewer"
+              target="_blank"
+              @click.stop
+            >
+              OSM H
+            </a>
+          </div>
         </div>
       </div>
       <p class="date">
@@ -129,10 +134,52 @@ header > a {
   gap: 0.25rem;
 }
 
-.actions {
-  display: flex;
+.fab {
+  position: relative;
   margin-left: auto;
   flex-shrink: 0;
+}
+
+.fab-toggle {
+  background: none;
+  border: 1px solid #dcdfe6;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0.15em 0.4em;
+  color: #333333;
+}
+
+.fab-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 5;
+  flex-direction: column;
+  background-color: #ffffff;
+  border: 1px solid #dcdfe6;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  min-width: max-content;
+}
+
+.fab:hover .fab-menu,
+.fab:focus-within .fab-menu {
+  display: flex;
+}
+
+.action-btn {
+  color: #000000;
+  padding: 0.4em 0.75em;
+  font-size: 0.75em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.action-btn:hover {
+  background-color: #f0f0f2;
 }
 
 :deep(.date),
@@ -144,16 +191,6 @@ header > a {
 :deep(.infos) {
   display: flex;
   gap: 0.5rem;
-}
-
-.action-btn {
-  flex-grow: 1;
-  color: #000000;
-  padding: 0.5em 1em;
-  font-size: 0.75em;
-  border: 1px solid #dcdfe6;
-  background-color: #ffffff;
-  text-align: center;
 }
 
 .status-content {

--- a/src/components/LoCha/LoChaReason.vue
+++ b/src/components/LoCha/LoChaReason.vue
@@ -66,7 +66,7 @@ span {
   flex-direction: column;
   background-color: #ffffff;
   font-size: 0.75rem;
-  border: 1px solid #000000;
+  border: 1px solid #4a4a4a;
   padding: 0.25rem;
 }
 

--- a/src/components/MapBbox.vue
+++ b/src/components/MapBbox.vue
@@ -96,7 +96,7 @@ defineExpose({ getZoom })
 
 <style scoped>
 .map-bbox {
-  border: 1px solid grey;
+  border: 1px solid #a0a0a4;
   height: 250px;
   width: 100%;
 }

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -86,11 +86,9 @@ function initMap() {
         },
         style: mapStyleUrl,
         cooperativeGestures: true,
-        attributionControl: {
-          compact: false,
-        },
+        attributionControl: false,
       })
-      map.value.addControl(new maplibre.NavigationControl())
+      map.value.addControl(new maplibre.FullscreenControl())
 
       map.value.on('load', handleMapOnLoad)
     }

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -85,6 +85,7 @@ function initMap() {
           maxZoom: 17,
         },
         style: mapStyleUrl,
+        cooperativeGestures: true,
         attributionControl: {
           compact: false,
         },

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -37,6 +37,7 @@ const map = shallowRef<maplibre.Map>()
 const isVisible = shallowRef(false)
 const popup = shallowRef<maplibre.Popup>()
 const hoveredStateFeature = shallowRef<maplibre.MapGeoJSONFeature>()
+let normalizedBbox: [number, number, number, number] | undefined
 
 watch(isVisible, (newState) => {
   if (newState) {
@@ -60,8 +61,10 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
-    const clipped = props.bbox
-      ? clipAndEnvelope(props.features, normalizeBbox(props.bbox))
+    normalizedBbox = props.bbox ? normalizeBbox(props.bbox) : undefined
+
+    const clipped = normalizedBbox
+      ? clipAndEnvelope(props.features, normalizedBbox)
       : turfFeatureCollection(props.features)
 
     if (clipped) {
@@ -122,8 +125,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (props.bbox) {
-    displayBbox(normalizeBbox(props.bbox))
+  if (normalizedBbox) {
+    displayBbox(normalizedBbox)
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -65,7 +65,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = turfBbox(clipped)
+      const boundsArray = normalizeBbox(turfBbox(clipped))
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
@@ -123,7 +123,7 @@ function handleMapOnLoad(): void {
     throw new Error('Call initMap() function first.')
 
   if (props.bbox) {
-    displayBbox(props.bbox)
+    displayBbox(normalizeBbox(props.bbox))
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -61,14 +61,14 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
-    normalizedBbox = props.bbox ? normalizeBbox(props.bbox) : undefined
+    normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
 
     const clipped = normalizedBbox
       ? clipAndEnvelope(props.features, normalizedBbox)
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = normalizeBbox(turfBbox(clipped))
+      const boundsArray = normalizeBboxForDisplay(turfBbox(clipped))
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -8,10 +8,10 @@ export type { Color, LoCha, LoChaGroup, Status } from '@/types'
  * A predefined object that maps status types to corresponding color codes.
  */
 export const loChaColors = {
-  new: '#52c41a',
-  delete: '#FF0000',
-  updateBefore: '#FFA479',
-  updateAfter: '#F2BE00',
+  new: '#1a7f37',
+  delete: '#cf222e',
+  updateBefore: '#953800',
+  updateAfter: '#0969da',
 } satisfies Color
 
 /**

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -10,7 +10,7 @@ export type { Color, LoCha, LoChaGroup, Status } from '@/types'
 export const loChaColors = {
   new: '#1a7f37',
   delete: '#cf222e',
-  updateBefore: '#953800',
+  updateBefore: '#a24200',
   updateAfter: '#0969da',
 } satisfies Color
 

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,2 +1,2 @@
 export const MAP_STYLE_URL = 'https://maps.cartoway.com/styles/positron/style.json'
-export const NO_GEOM_COLOR = '#f4f4f5'
+export const NO_GEOM_COLOR = '#ebebee'

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ export type {
   ActionTypeOptions,
   ApiLink,
   ApiLinkGroups,
+  Changeset,
+  ChangesetsSlotProps,
   IFeature,
   LinkMetadataSlotProps,
   LoChaData,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,5 +1,5 @@
 import type { ComputedRef, Ref } from 'vue'
-import type { Actions, ApiLink, IFeature, LoChaData, Reason } from './api'
+import type { Actions, ApiLink, Changeset, IFeature, LoChaData, Reason } from './api'
 
 /**
  * The possible statuses for features in the system.
@@ -45,6 +45,14 @@ export interface TagsDiffSlotProps {
  */
 export interface LinkMetadataSlotProps {
   links: ApiLink[]
+  index: number
+}
+
+/**
+ * Props passed through the `changesets` slot across the LoCha component hierarchy.
+ */
+export interface ChangesetsSlotProps {
+  changesets: Changeset[]
   index: number
 }
 

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -46,16 +46,25 @@ export function clipAndEnvelope(
   return turfEnvelope(fc)
 }
 
-// ~100m epsilon padding in degrees, ensures features on bbox edges are not excluded
-const BBOX_PADDING = 0.001
+// ~100m padding in degrees, ensures features on bbox edges are not excluded during clipping
+const CLIPPING_PADDING = 0.001
 
-export function normalizeBbox(
-  bbox: GeoJSON.BBox,
-): [number, number, number, number] {
+// ~10m padding in degrees, used for map display bounds (smaller to avoid over-zooming on degenerate bboxes)
+const DISPLAY_PADDING = 0.0001
+
+function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
-    bbox[0] - BBOX_PADDING,
-    bbox[1] - BBOX_PADDING,
-    bbox[2] + BBOX_PADDING,
-    bbox[3] + BBOX_PADDING,
+    bbox[0] - padding,
+    bbox[1] - padding,
+    bbox[2] + padding,
+    bbox[3] + padding,
   ]
+}
+
+export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, number, number] {
+  return padBbox(bbox, CLIPPING_PADDING)
+}
+
+export function normalizeBboxForDisplay(bbox: GeoJSON.BBox): [number, number, number, number] {
+  return padBbox(bbox, DISPLAY_PADDING)
 }

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -46,25 +46,16 @@ export function clipAndEnvelope(
   return turfEnvelope(fc)
 }
 
-// ~100m padding in degrees, used to expand degenerate (zero-area) bboxes
+// ~100m epsilon padding in degrees, ensures features on bbox edges are not excluded
 const BBOX_PADDING = 0.001
 
 export function normalizeBbox(
   bbox: GeoJSON.BBox,
 ): [number, number, number, number] {
-  let minX = bbox[0]
-  let minY = bbox[1]
-  let maxX = bbox[2]
-  let maxY = bbox[3]
-
-  if (minX === maxX) {
-    minX -= BBOX_PADDING
-    maxX += BBOX_PADDING
-  }
-  if (minY === maxY) {
-    minY -= BBOX_PADDING
-    maxY += BBOX_PADDING
-  }
-
-  return [minX, minY, maxX, maxY]
+  return [
+    bbox[0] - BBOX_PADDING,
+    bbox[1] - BBOX_PADDING,
+    bbox[2] + BBOX_PADDING,
+    bbox[3] + BBOX_PADDING,
+  ]
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBbox } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -96,54 +96,59 @@ describe('clipAndEnvelope', () => {
   })
 })
 
-describe('normalizeBbox', () => {
-  it('always adds epsilon padding to non-degenerate bbox', () => {
+describe('normalizeBboxForClipping', () => {
+  it('adds ~100m padding to non-degenerate bbox', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
+    const result = normalizeBboxForClipping(bbox)
     expect(result[0]).toBeLessThan(-122.5)
     expect(result[1]).toBeLessThan(37.7)
     expect(result[2]).toBeGreaterThan(-122.4)
     expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('adds epsilon padding in standard GeoJSON format', () => {
-    const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(43.4)
-    expect(result[1]).toBeLessThan(-1.6)
-    expect(result[2]).toBeGreaterThan(43.5)
-    expect(result[3]).toBeGreaterThan(-1.5)
-  })
-
-  it('pads degenerate bbox where minX === maxX', () => {
-    const bbox = [-122.5, 37.7, -122.5, 37.8] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[2]).toBeGreaterThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('pads degenerate bbox where minY === maxY', () => {
-    const bbox = [-122.5, 37.7, -122.4, 37.7] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[2]).toBeGreaterThan(-122.4)
-    expect(result[3]).toBeGreaterThan(37.7)
   })
 
   it('pads fully degenerate bbox (single point)', () => {
     const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
-    const result = normalizeBbox(bbox)
+    const result = normalizeBboxForClipping(bbox)
     expect(result[0]).toBeLessThan(-1.572)
     expect(result[2]).toBeGreaterThan(-1.572)
     expect(result[1]).toBeLessThan(43.457)
     expect(result[3]).toBeGreaterThan(43.457)
   })
 
-  it('applies exact BBOX_PADDING of 0.001', () => {
+  it('applies exact clipping padding of 0.001', () => {
     const bbox = [0, 0, 10, 10] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
+    expect(normalizeBboxForClipping(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
+  })
+})
+
+describe('normalizeBboxForDisplay', () => {
+  it('adds ~10m padding to non-degenerate bbox', () => {
+    const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
+    const result = normalizeBboxForDisplay(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
+    expect(result[3]).toBeGreaterThan(37.8)
+  })
+
+  it('pads fully degenerate bbox (single point)', () => {
+    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
+    const result = normalizeBboxForDisplay(bbox)
+    expect(result[0]).toBeLessThan(-1.572)
+    expect(result[2]).toBeGreaterThan(-1.572)
+    expect(result[1]).toBeLessThan(43.457)
+    expect(result[3]).toBeGreaterThan(43.457)
+  })
+
+  it('applies exact display padding of 0.0001', () => {
+    const bbox = [0, 0, 10, 10] as [number, number, number, number]
+    expect(normalizeBboxForDisplay(bbox)).toEqual([-0.0001, -0.0001, 10.0001, 10.0001])
+  })
+
+  it('applies smaller padding than clipping variant', () => {
+    const bbox = [0, 0, 0, 0] as [number, number, number, number]
+    const clipping = normalizeBboxForClipping(bbox)
+    const display = normalizeBboxForDisplay(bbox)
+    expect(Math.abs(display[0])).toBeLessThan(Math.abs(clipping[0]))
   })
 })

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -97,15 +97,22 @@ describe('clipAndEnvelope', () => {
 })
 
 describe('normalizeBbox', () => {
-  it('returns bbox unchanged when non-degenerate and no swap needed', () => {
-    // minX and maxX outside [-90, 90] → no swap
+  it('always adds epsilon padding to non-degenerate bbox', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([-122.5, 37.7, -122.4, 37.8])
+    const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
+    expect(result[3]).toBeGreaterThan(37.8)
   })
 
-  it('returns bbox unchanged when already in standard GeoJSON format', () => {
+  it('adds epsilon padding in standard GeoJSON format', () => {
     const bbox = [43.4, -1.6, 43.5, -1.5] as [number, number, number, number]
-    expect(normalizeBbox(bbox)).toEqual([43.4, -1.6, 43.5, -1.5])
+    const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(43.4)
+    expect(result[1]).toBeLessThan(-1.6)
+    expect(result[2]).toBeGreaterThan(43.5)
+    expect(result[3]).toBeGreaterThan(-1.5)
   })
 
   it('pads degenerate bbox where minX === maxX', () => {
@@ -113,17 +120,17 @@ describe('normalizeBbox', () => {
     const result = normalizeBbox(bbox)
     expect(result[0]).toBeLessThan(-122.5)
     expect(result[2]).toBeGreaterThan(-122.5)
-    expect(result[1]).toBe(37.7)
-    expect(result[3]).toBe(37.8)
+    expect(result[1]).toBeLessThan(37.7)
+    expect(result[3]).toBeGreaterThan(37.8)
   })
 
   it('pads degenerate bbox where minY === maxY', () => {
     const bbox = [-122.5, 37.7, -122.4, 37.7] as [number, number, number, number]
     const result = normalizeBbox(bbox)
+    expect(result[0]).toBeLessThan(-122.5)
     expect(result[1]).toBeLessThan(37.7)
+    expect(result[2]).toBeGreaterThan(-122.4)
     expect(result[3]).toBeGreaterThan(37.7)
-    expect(result[0]).toBe(-122.5)
-    expect(result[2]).toBe(-122.4)
   })
 
   it('pads fully degenerate bbox (single point)', () => {
@@ -133,5 +140,10 @@ describe('normalizeBbox', () => {
     expect(result[2]).toBeGreaterThan(-1.572)
     expect(result[1]).toBeLessThan(43.457)
     expect(result[3]).toBeGreaterThan(43.457)
+  })
+
+  it('applies exact BBOX_PADDING of 0.001', () => {
+    const bbox = [0, 0, 10, 10] as [number, number, number, number]
+    expect(normalizeBbox(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(({ command, mode }) => {
   const baseConfig = {
     resolve: {
       alias: {
-        '@': resolve(__dirname, './src'),
+        '@': resolve(import.meta.dirname, './src'),
       },
     },
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,7 @@ __metadata:
     "@turf/boolean-equal": "npm:^7.3.4"
     "@turf/envelope": "npm:^7.3.4"
     "@turf/helpers": "npm:^7.3.4"
+    "@types/node": "npm:^25.6.0"
     "@types/underscore": "npm:^1.13.0"
     "@vitejs/plugin-vue": "npm:^6.0.5"
     "@vitest/coverage-v8": "npm:^4.1.0"
@@ -2190,6 +2191,15 @@ __metadata:
   version: 2.1.0
   resolution: "@types/ms@npm:2.1.0"
   checksum: 10c0/5ce692ffe1549e1b827d99ef8ff71187457e0eb44adbae38fdf7b9a74bae8d20642ee963c14516db1d35fa2652e65f47680fdf679dcbde52bbfadd021f497225
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^25.6.0":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
   languageName: node
   linkType: hard
 
@@ -7455,6 +7465,13 @@ __metadata:
   version: 1.13.8
   resolution: "underscore@npm:1.13.8"
   checksum: 10c0/6677688daeda30484823e77c0b89ce4dcf29964a77d5a06f37299c007ab4bb1c66a0ff75e0d274620b62a1fe2a6ba29879f8214533ca611d71a1ae504f2bfc9b
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Replace status colors with WCAG-accessible palette: darker green (`#1a7f37`), crimson red (`#cf222e`), dark amber (`#953800`) for before, blue (`#0969da`) for after
- The warm/cold before/after opposition works for all types of color vision deficiency
- Consolidate grays: soften `#000000` borders to `#4a4a4a`, unify border grays to `#c8c8cc`/`#a0a0a4`, darken `no_changes` bg to `#ebebee` (visible on host app alternating `#f5f5f8`/`#e0e0e4` backgrounds), replace `grey` keyword with `#636366`, use white FAB bg with stronger border

### Before → After color mapping

| Role | Before | After |
|------|--------|-------|
| `new` | `#52c41a` | `#1a7f37` |
| `delete` | `#FF0000` | `#cf222e` |
| `updateBefore` | `#FFA479` | `#953800` |
| `updateAfter` | `#F2BE00` | `#0969da` |

## Test plan

- [ ] Visual check on the demo app
- [ ] Verify diff table colors (added, deleted, changed rows)
- [ ] Verify map layer colors match the new palette
- [ ] Check FAB button visibility on both light (`#f5f5f8`) and dark (`#e0e0e4`) alternating backgrounds in clearance-frontend
- [ ] Verify with a colorblind simulator (e.g. Chrome DevTools → Rendering → Emulate vision deficiencies)

Closes #133