### PR TITLE
fix: ui polish, color palette and group-name improvements

### DIFF
--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -197,7 +197,7 @@ thead th {
 table,
 th,
 td {
-  border: 1px solid #000000;
+  border: 1px solid #3d3d3d;
   border-collapse: collapse;
   padding: 0.15rem;
 }
@@ -232,7 +232,7 @@ td {
 }
 
 .no_changes {
-  background-color: #f4f4f5;
+  background-color: #eaeaee;
 }
 
 thead th > div {

--- a/src/components/LoCha/LoChaDiffTag.vue
+++ b/src/components/LoCha/LoChaDiffTag.vue
@@ -46,7 +46,7 @@ defineProps<{
 }
 
 .no_changes {
-  background-color: #f4f4f5;
+  background-color: #eaeaee;
 }
 
 .attribute-changed {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -33,27 +33,37 @@ const { loCha, getBeforeFeatures, getAfterFeatures } = inject(LOCHA_KEY)!
 if (!loCha.value)
   throw new Error('LoCha is empty.')
 
-const groupName = computed(() => {
+const groupNameParts = computed(() => {
   const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
   const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
 
-  const beforeLabel = beforeNames.length > 0 ? beforeNames.join(', ') : '(unnamed)'
-  const afterLabel = afterNames.length > 0 ? afterNames.join(', ') : '(unnamed)'
+  const before = beforeNames.length > 0 ? beforeNames.join(', ') : null
+  const after = afterNames.length > 0 ? afterNames.join(', ') : '(unnamed)'
 
-  if (beforeLabel === afterLabel)
-    return beforeLabel
+  if (before === after)
+    return { before: null, after }
 
-  return `${beforeLabel} → ${afterLabel}`
+  return { before, after }
 })
+
+const groupNameTitle = computed(() =>
+  groupNameParts.value.before
+    ? `${groupNameParts.value.before} → ${groupNameParts.value.after}`
+    : groupNameParts.value.after,
+)
 </script>
 
 <template>
   <div :id="id" class="locha-group">
     <div class="group-header">
-      <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
-      <h3 class="group-name">
-        {{ groupName }}
-      </h3>
+      <div class="header-start">
+        <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
+        <h3 class="group-name" :title="groupNameTitle">
+          <span v-if="groupNameParts.before" class="name-before">{{ groupNameParts.before }}</span>
+          <span v-if="groupNameParts.before" class="name-separator"> → </span>
+          <span class="name-after">{{ groupNameParts.after }}</span>
+        </h3>
+      </div>
       <div class="header-center">
         <slot name="header-center" :index="index" />
       </div>
@@ -113,18 +123,46 @@ const groupName = computed(() => {
 
 .group-header {
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: center;
   gap: 0.5rem;
-  background-color: #f0f0f2;
   padding: 0.5rem;
   border-bottom: 1px solid #cecece;
+}
+
+.header-start {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
 }
 
 .group-name {
   margin: 0;
   font-size: 1rem;
   font-weight: 500;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.name-before {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.name-separator {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.name-after {
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .anchor-button {
@@ -143,7 +181,7 @@ const groupName = computed(() => {
 }
 
 .v-map {
-  border: 1px solid #000000;
+  border: 1px solid #3d3d3d;
 }
 
 ul {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -25,6 +25,7 @@ defineSlots<{
 
 const runtimeSlots = useSlots()
 const gridColumns = computed(() => runtimeSlots['content-start'] ? 'repeat(4, minmax(0, 1fr))' : 'repeat(3, minmax(0, 1fr))')
+const headerGridColumns = computed(() => runtimeSlots['header-end'] ? 'minmax(0, 1fr) minmax(0, 1fr) auto' : 'minmax(0, 1fr) minmax(0, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -123,7 +124,7 @@ const groupNameTitle = computed(() =>
 
 .group-header {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: v-bind(headerGridColumns);
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;
@@ -166,6 +167,7 @@ const groupNameTitle = computed(() =>
 }
 
 .anchor-button {
+  flex-shrink: 0;
   border: 2px solid #cecece;
   background-color: #ffffff;
   text-decoration: none;

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -31,13 +31,30 @@ function josmTargetName(): string {
   return `hidden_josm_target_${instanceId}`
 }
 
+let internalNavigation = false
+
 function navigateToHash(hash: string) {
+  if (currentHash.value === hash) {
+    internalNavigation = true
+    currentHash.value = undefined
+    history.replaceState(null, '', ' ')
+    nextTick(() => {
+      internalNavigation = false
+    })
+    return
+  }
+  internalNavigation = true
   currentHash.value = hash
   history.replaceState(null, '', hash)
-  nextTick(() => scrollToSection(hash, { container: listRef.value ?? undefined }))
+  nextTick(() => {
+    internalNavigation = false
+    scrollToSection(hash, { container: listRef.value ?? undefined })
+  })
 }
 
 watch(() => props.hash, (newValue) => {
+  if (internalNavigation)
+    return
   currentHash.value = newValue
   if (newValue) {
     nextTick(() => scrollToSection(newValue, { container: listRef.value ?? undefined }))

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -37,7 +37,7 @@ function navigateToHash(hash: string) {
   if (currentHash.value === hash) {
     internalNavigation = true
     currentHash.value = undefined
-    history.replaceState(null, '', ' ')
+    history.replaceState(null, '', `${location.pathname}${location.search}`)
     nextTick(() => {
       internalNavigation = false
     })

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -100,6 +100,7 @@ const color = computed(() => loChaColors[status.value])
         📅 {{ props.feature.properties.created }}
       </p>
       <a
+        v-if="feature.properties.username"
         :href="getOsmUserUrl(feature.properties.username)"
         :title="`View ${feature.properties.username} OSM profile`"
         target="_blank"
@@ -141,8 +142,8 @@ header > a {
 }
 
 .fab-toggle {
-  background-color: #e8e8ea;
-  border: 1px solid #c0c0c2;
+  background-color: #d0d0d4;
+  border: 1px solid #a8a8ac;
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.75rem;
@@ -160,7 +161,7 @@ header > a {
   z-index: 5;
   flex-direction: column;
   background-color: #ffffff;
-  border: 1px solid #dcdfe6;
+  border: 1px solid #cecece;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   min-width: max-content;
@@ -172,7 +173,7 @@ header > a {
 }
 
 .action-btn {
-  color: #000000;
+  color: #3d3d3d;
   padding: 0.4em 0.75em;
   font-size: 0.75em;
   text-decoration: none;
@@ -180,13 +181,13 @@ header > a {
 }
 
 .action-btn:hover {
-  background-color: #f0f0f2;
+  background-color: #eaeaee;
 }
 
 :deep(.date),
 :deep(.title) {
   font-size: 12px;
-  color: grey;
+  color: #666666;
 }
 
 :deep(.infos) {

--- a/src/components/LoCha/LoChaReason.vue
+++ b/src/components/LoCha/LoChaReason.vue
@@ -66,7 +66,7 @@ span {
   flex-direction: column;
   background-color: #ffffff;
   font-size: 0.75rem;
-  border: 1px solid #000000;
+  border: 1px solid #3d3d3d;
   padding: 0.25rem;
 }
 

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -8,10 +8,10 @@ export type { Color, LoCha, LoChaGroup, Status } from '@/types'
  * A predefined object that maps status types to corresponding color codes.
  */
 export const loChaColors = {
-  new: '#52c41a',
-  delete: '#FF0000',
-  updateBefore: '#FFA479',
-  updateAfter: '#F2BE00',
+  new: '#1a7f37',
+  delete: '#cf222e',
+  updateBefore: '#953800',
+  updateAfter: '#0969da',
 } satisfies Color
 
 /**

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -11,19 +11,19 @@ export type Status = 'new' | 'delete' | 'updateBefore' | 'updateAfter'
 
 /**
  * The Color type defines colors based on feature status.
- * - 'new' maps to '#52c41a'
- * - 'delete' maps to '#FF0000'
- * - 'updateBefore' maps to '#FFA479'
- * - 'updateAfter' maps to '#F2BE00'
+ * - 'new' maps to '#1a7f37'
+ * - 'delete' maps to '#cf222e'
+ * - 'updateBefore' maps to '#953800'
+ * - 'updateAfter' maps to '#0969da'
  */
 export type Color = {
   [key in Status]: key extends 'new'
-    ? '#52c41a'
+    ? '#1a7f37'
     : key extends 'delete'
-      ? '#FF0000'
+      ? '#cf222e'
       : key extends 'updateBefore'
-        ? '#FFA479'
-        : '#F2BE00'
+        ? '#953800'
+        : '#0969da'
 }
 
 export type LoChaGroup = IFeature[]


### PR DESCRIPTION
## Summary

- **#139** Remove grey `background-color` from `.group-header`
- **#138** Improve group-name: hide `(unnamed)` + arrow when `before` is empty; show name once when `before === after`
- **#140** Apply text ellipsis on the `before` value only — `after` always fully visible
- **#141** Toggle-anchor: clicking the same anchor deselects; guard `watch` against external `props.hash` override
- **#142** Hide OSM profile icon when `username` is absent
- **#133** Update status colors for accessibility/colorblind support (`new=#1a7f37`, `delete=#cf222e`, `updateBefore=#953800`, `updateAfter=#0969da`); consolidate grays (`#000000→#3d3d3d`, `grey→#666666`, `no_changes→#eaeaee`, FAB button more visible)

## Test plan

- [ ] Group header has no grey background
- [ ] Group with no before name shows only after name (no arrow, no "(unnamed)")
- [ ] Group with identical before/after name shows the name once
- [ ] Long before name truncates with ellipsis; after name stays fully visible
- [ ] Objects without a username don't show the profile icon
- [ ] Clicking a group anchor selects it (red border); clicking another deselects the first
- [ ] Clicking the same anchor again deselects it
- [ ] Status colors visually distinguishable (green/red/amber/blue)
- [ ] No_changes rows distinguishable from host app alternating backgrounds
- [ ] FAB button visible on both `#f5f5f8` and `#e0e0e4` backgrounds