### PR TITLE
Release 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -25,7 +25,6 @@ defineSlots<{
 
 const runtimeSlots = useSlots()
 const gridColumns = computed(() => runtimeSlots['content-start'] ? 'repeat(4, minmax(0, 1fr))' : 'repeat(3, minmax(0, 1fr))')
-const headerGridColumns = computed(() => runtimeSlots['header-end'] ? 'minmax(0, 1fr) minmax(0, 1fr) auto' : 'minmax(0, 1fr) minmax(0, 1fr)')
 
 const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 
@@ -69,7 +68,7 @@ const groupNameTitle = computed(() => {
       <div class="header-center">
         <slot name="header-center" :index="index" />
       </div>
-      <div v-if="$slots['header-end']" class="header-end">
+      <div class="header-end">
         <slot name="header-end" :index="index" />
       </div>
     </div>
@@ -125,7 +124,7 @@ const groupNameTitle = computed(() => {
 
 .group-header {
   display: grid;
-  grid-template-columns: v-bind(headerGridColumns);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem;

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -12,10 +12,15 @@ export const LAYERS = {
     id: 'bbox-layer',
     type: 'line',
     source: BBOX_SOURCE_ID,
+    layout: {
+      'line-join': 'miter',
+      'line-cap': 'square',
+    },
     paint: {
       'line-color': '#000000',
-      'line-width': 1,
-      'line-dasharray': [2, 2],
+      'line-width': 2,
+      'line-dasharray': [4, 4],
+      'line-offset': -6,
     },
   },
   PolygonBorder: {


### PR DESCRIPTION
## Changes

### Styles
* style: improve bbox layer with offset and sharper corners by @wazolab
* style: always use 3 equal columns in group-header to keep header-center centered by @wazolab

### Chores
* chore: bump version to 0.4.3 by @wazolab

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.4.3