### PR TITLE
Release 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -12,10 +12,15 @@ export const LAYERS = {
     id: 'bbox-layer',
     type: 'line',
     source: BBOX_SOURCE_ID,
+    layout: {
+      'line-join': 'miter',
+      'line-cap': 'square',
+    },
     paint: {
       'line-color': '#000000',
-      'line-width': 1,
-      'line-dasharray': [2, 2],
+      'line-width': 2,
+      'line-dasharray': [4, 4],
+      'line-offset': -6,
     },
   },
   PolygonBorder: {


### PR DESCRIPTION
## Changes

### Styles
* style: improve bbox layer with offset and sharper corners by @wazolab
* style: always use 3 equal columns in group-header to keep header-center centered by @wazolab

### Chores
* chore: bump version to 0.4.3 by @wazolab

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.4.3