### PR TITLE
fix: table cell overflow in Firefox in LoChaDiff

### DIFF
--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -186,7 +186,7 @@ const tagDiffs = computed(() => {
 }
 
 table {
-  table-layout: fixed;
+  table-layout: auto;
 }
 
 thead th {


### PR DESCRIPTION
## Summary

- Replace `table-layout: fixed` with `table-layout: auto` in `LoChaDiff.vue`
- Firefox strictly distributes column widths equally under `fixed` layout (without explicit column widths), ignoring `white-space: nowrap` on `td.key`, causing cell content to overflow
- `auto` layout computes widths from content, fixing the overflow in Firefox without affecting Chrome/Brave

Closes #151