### PR TITLE
fix: table overflows parent in LoChaDiff with long values

### DIFF
--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -241,6 +241,7 @@ thead th > div {
 
 td {
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 
 td.key {


### PR DESCRIPTION
## Summary

- Add `overflow-wrap: anywhere` to `td` in `LoChaDiff.vue`
- `anywhere` reduces minimum content width to zero, allowing the table to be constrained by its parent while wrapping long values
- `white-space: nowrap` on `td.key` takes precedence, keeping keys on one line

Same fix as teritorio/clearance-frontend#420.

Closes #153