### PR TITLE
refactor: simplify bbox rendering pipeline in VMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -241,6 +241,7 @@ thead th > div {
 
 td {
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 
 td.key {

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -186,7 +186,7 @@ const tagDiffs = computed(() => {
 }
 
 table {
-  table-layout: fixed;
+  table-layout: auto;
 }
 
 thead th {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -125,7 +125,8 @@ function handleMapOnLoad(): void {
     throw new Error('Call initMap() function first.')
 
   if (normalizedBbox) {
-    displayBbox(normalizedBbox)
+    const isDegenerate = props.bbox![0] === props.bbox![2] || props.bbox![1] === props.bbox![3]
+    displayBbox(isDegenerate ? normalizeBboxForBboxLayer(props.bbox!) : normalizedBbox)
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -68,7 +68,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = normalizeBboxForDisplay(turfBbox(clipped))
+      const boundsArray = turfBbox(clipped) as [number, number, number, number]
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
@@ -124,9 +124,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (normalizedBbox) {
-    const isDegenerate = props.bbox![0] === props.bbox![2] || props.bbox![1] === props.bbox![3]
-    displayBbox(isDegenerate ? normalizeBboxForBboxLayer(props.bbox!) : normalizedBbox)
+  if (props.bbox) {
+    displayBbox(normalizeBboxForBboxLayer(props.bbox))
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -18,9 +18,9 @@ export const LAYERS = {
     },
     paint: {
       'line-color': '#000000',
-      'line-width': 2,
-      'line-dasharray': [4, 4],
-      'line-offset': -6,
+      'line-width': 1,
+      'line-dasharray': [2, 2],
+      'line-offset': -32,
     },
   },
   PolygonBorder: {

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -20,7 +20,7 @@ export const LAYERS = {
       'line-color': '#000000',
       'line-width': 1,
       'line-dasharray': [2, 2],
-      'line-offset': -32,
+      'line-offset': -24,
     },
   },
   PolygonBorder: {

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -49,11 +49,8 @@ export function clipAndEnvelope(
 // ~100m padding in degrees, ensures features on bbox edges are not excluded during clipping
 const CLIPPING_PADDING = 0.001
 
-// ~10m padding in degrees, used for map display bounds (smaller to avoid over-zooming on degenerate bboxes)
-const DISPLAY_PADDING = 0.0001
-
-// ~50m padding in degrees, used for bbox layer display on degenerate bboxes (e.g. point)
-const BBOX_LAYER_PADDING = 0.0005
+// Minimal expansion for degenerate bboxes (point/line), visual padding comes from line-offset
+const DEGENERATE_BBOX_PADDING = 0.00001
 
 function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
@@ -68,11 +65,7 @@ export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, n
   return padBbox(bbox, CLIPPING_PADDING)
 }
 
-export function normalizeBboxForDisplay(bbox: GeoJSON.BBox): [number, number, number, number] {
-  return padBbox(bbox, DISPLAY_PADDING)
-}
-
 export function normalizeBboxForBboxLayer(bbox: GeoJSON.BBox): [number, number, number, number] {
   const isDegenerate = bbox[0] === bbox[2] || bbox[1] === bbox[3]
-  return isDegenerate ? padBbox(bbox, BBOX_LAYER_PADDING) : (bbox as [number, number, number, number])
+  return isDegenerate ? padBbox(bbox, DEGENERATE_BBOX_PADDING) : (bbox as [number, number, number, number])
 }

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -52,6 +52,9 @@ const CLIPPING_PADDING = 0.001
 // ~10m padding in degrees, used for map display bounds (smaller to avoid over-zooming on degenerate bboxes)
 const DISPLAY_PADDING = 0.0001
 
+// ~50m padding in degrees, used for bbox layer display on degenerate bboxes (e.g. point)
+const BBOX_LAYER_PADDING = 0.0005
+
 function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
     bbox[0] - padding,
@@ -67,4 +70,9 @@ export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, n
 
 export function normalizeBboxForDisplay(bbox: GeoJSON.BBox): [number, number, number, number] {
   return padBbox(bbox, DISPLAY_PADDING)
+}
+
+export function normalizeBboxForBboxLayer(bbox: GeoJSON.BBox): [number, number, number, number] {
+  const isDegenerate = bbox[0] === bbox[2] || bbox[1] === bbox[3]
+  return isDegenerate ? padBbox(bbox, BBOX_LAYER_PADDING) : (bbox as [number, number, number, number])
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -118,37 +118,5 @@ describe('normalizeBboxForClipping', () => {
   it('applies exact clipping padding of 0.001', () => {
     const bbox = [0, 0, 10, 10] as [number, number, number, number]
     expect(normalizeBboxForClipping(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
-  })
-})
-
-describe('normalizeBboxForDisplay', () => {
-  it('adds ~10m padding to non-degenerate bbox', () => {
-    const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    const result = normalizeBboxForDisplay(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[2]).toBeGreaterThan(-122.4)
-    expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('pads fully degenerate bbox (single point)', () => {
-    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
-    const result = normalizeBboxForDisplay(bbox)
-    expect(result[0]).toBeLessThan(-1.572)
-    expect(result[2]).toBeGreaterThan(-1.572)
-    expect(result[1]).toBeLessThan(43.457)
-    expect(result[3]).toBeGreaterThan(43.457)
-  })
-
-  it('applies exact display padding of 0.0001', () => {
-    const bbox = [0, 0, 10, 10] as [number, number, number, number]
-    expect(normalizeBboxForDisplay(bbox)).toEqual([-0.0001, -0.0001, 10.0001, 10.0001])
-  })
-
-  it('applies smaller padding than clipping variant', () => {
-    const bbox = [0, 0, 0, 0] as [number, number, number, number]
-    const clipping = normalizeBboxForClipping(bbox)
-    const display = normalizeBboxForDisplay(bbox)
-    expect(Math.abs(display[0])).toBeLessThan(Math.abs(clipping[0]))
   })
 })


### PR DESCRIPTION
Closes #155

## Changes

- `line-offset: -24` on the bbox layer (visual padding via line offset rather than geo coordinates)
- Remove `normalizeBboxForDisplay` — `fitBoundsOptions.padding: 60` handles the camera margin
- Degenerate bbox (Point): minimal geo expansion (`0.00001°`), visual padding from `line-offset`
- Remove duplicated `isDegenerate` detection in `VMap.vue`

## Note

Version bump pending — more work in progress on this release.