### PR TITLE
release: v0.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { GroupSlotProps, LoChaData, ObjectDetailSlotProps } from '@/types'
-import { provide, watch } from 'vue'
+import { computed, provide, watch } from 'vue'
 import LoChaGroupList from '@/components/LoCha/LoChaGroupList.vue'
 import { useLoCha } from '@/composables/useLoCha'
 import { LOCHA_INSTANCE_ID_KEY, LOCHA_KEY, MAP_STYLE_URL_KEY, REASON_COLLAPSED_KEY } from '@/constants/injectionKeys'
@@ -33,8 +33,11 @@ provide(LOCHA_KEY, loChaInstance)
 
 const {
   featureCount,
+  groups,
   setLoCha,
 } = loChaInstance
+
+const isSingle = computed(() => groups.value.length === 1)
 
 watch(() => props.data, (newValue) => {
   if (newValue) {
@@ -44,7 +47,7 @@ watch(() => props.data, (newValue) => {
 </script>
 
 <template>
-  <section class="locha">
+  <section class="locha" :class="{ 'locha--single': isSingle }">
     <p v-if="!featureCount" class="user-feedback">
       ⚠️ No data
     </p>
@@ -71,6 +74,10 @@ watch(() => props.data, (newValue) => {
   flex-direction: column;
   height: inherit;
   padding: 1rem;
+}
+
+.locha--single {
+  padding: 0;
 }
 
 .locha-group-list {

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -241,6 +241,7 @@ thead th > div {
 
 td {
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 
 td.key {

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -186,7 +186,7 @@ const tagDiffs = computed(() => {
 }
 
 table {
-  table-layout: fixed;
+  table-layout: auto;
 }
 
 thead th {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -189,7 +189,7 @@ const groupNameTitle = computed(() => {
 }
 
 .v-map {
-  border: 1px solid #000000;
+  border: 1px solid lightgrey;
 }
 
 ul {

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -116,7 +116,6 @@ const color = computed(() => loChaColors[status.value])
 <style lang="css" scoped>
 article {
   border: 2px solid v-bind(color);
-  background-color: color-mix(in srgb, v-bind(color) 20%, white 80%);
   display: flex;
   flex-direction: column;
   gap: 4px;

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -124,8 +124,9 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (props.bbox) {
-    displayBbox(normalizeBboxForBboxLayer(props.bbox))
+  if (normalizedBbox) {
+    const isDegenerate = props.bbox![0] === props.bbox![2] || props.bbox![1] === props.bbox![3]
+    displayBbox(isDegenerate ? normalizeBboxForBboxLayer(props.bbox!) : normalizedBbox)
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -68,7 +68,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = normalizeBboxForDisplay(turfBbox(clipped))
+      const boundsArray = turfBbox(clipped) as [number, number, number, number]
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
@@ -124,9 +124,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (normalizedBbox) {
-    const isDegenerate = props.bbox![0] === props.bbox![2] || props.bbox![1] === props.bbox![3]
-    displayBbox(isDegenerate ? normalizeBboxForBboxLayer(props.bbox!) : normalizedBbox)
+  if (props.bbox) {
+    displayBbox(normalizeBboxForBboxLayer(props.bbox))
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -20,7 +20,7 @@ export const LAYERS = {
       'line-color': '#000000',
       'line-width': 1,
       'line-dasharray': [2, 2],
-      'line-offset': -32,
+      'line-offset': -24,
     },
   },
   PolygonBorder: {

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -49,11 +49,8 @@ export function clipAndEnvelope(
 // ~100m padding in degrees, ensures features on bbox edges are not excluded during clipping
 const CLIPPING_PADDING = 0.001
 
-// ~10m padding in degrees, used for map display bounds (smaller to avoid over-zooming on degenerate bboxes)
-const DISPLAY_PADDING = 0.0001
-
-// ~50m padding in degrees, used for bbox layer display on degenerate bboxes (e.g. point)
-const BBOX_LAYER_PADDING = 0.0005
+// Minimal expansion for degenerate bboxes (point/line), visual padding comes from line-offset
+const DEGENERATE_BBOX_PADDING = 0.00001
 
 function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
@@ -68,11 +65,7 @@ export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, n
   return padBbox(bbox, CLIPPING_PADDING)
 }
 
-export function normalizeBboxForDisplay(bbox: GeoJSON.BBox): [number, number, number, number] {
-  return padBbox(bbox, DISPLAY_PADDING)
-}
-
 export function normalizeBboxForBboxLayer(bbox: GeoJSON.BBox): [number, number, number, number] {
   const isDegenerate = bbox[0] === bbox[2] || bbox[1] === bbox[3]
-  return isDegenerate ? padBbox(bbox, BBOX_LAYER_PADDING) : (bbox as [number, number, number, number])
+  return isDegenerate ? padBbox(bbox, DEGENERATE_BBOX_PADDING) : (bbox as [number, number, number, number])
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBboxForClipping } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -118,5 +118,33 @@ describe('normalizeBboxForClipping', () => {
   it('applies exact clipping padding of 0.001', () => {
     const bbox = [0, 0, 10, 10] as [number, number, number, number]
     expect(normalizeBboxForClipping(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
+  })
+})
+
+describe('normalizeBboxForBboxLayer', () => {
+  it('returns bbox as-is for non-degenerate bbox', () => {
+    const bbox = [0, 0, 10, 10] as [number, number, number, number]
+    expect(normalizeBboxForBboxLayer(bbox)).toEqual([0, 0, 10, 10])
+  })
+
+  it('expands fully degenerate bbox (single point)', () => {
+    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
+    const result = normalizeBboxForBboxLayer(bbox)
+    expect(result[0]).toBeLessThan(-1.572)
+    expect(result[2]).toBeGreaterThan(-1.572)
+    expect(result[1]).toBeLessThan(43.457)
+    expect(result[3]).toBeGreaterThan(43.457)
+  })
+
+  it('expands degenerate bbox with zero width (vertical line)', () => {
+    const bbox = [2.0, 48.0, 2.0, 48.5] as [number, number, number, number]
+    const result = normalizeBboxForBboxLayer(bbox)
+    expect(result[0]).toBeLessThan(2.0)
+    expect(result[2]).toBeGreaterThan(2.0)
+  })
+
+  it('applies minimal expansion of 0.00001 on degenerate bbox', () => {
+    const bbox = [0, 0, 0, 0] as [number, number, number, number]
+    expect(normalizeBboxForBboxLayer(bbox)).toEqual([-0.00001, -0.00001, 0.00001, 0.00001])
   })
 })

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBboxForClipping, normalizeBboxForDisplay } from '@/utils/geom'
+import { clipAndEnvelope, normalizeBboxForClipping } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -118,37 +118,5 @@ describe('normalizeBboxForClipping', () => {
   it('applies exact clipping padding of 0.001', () => {
     const bbox = [0, 0, 10, 10] as [number, number, number, number]
     expect(normalizeBboxForClipping(bbox)).toEqual([-0.001, -0.001, 10.001, 10.001])
-  })
-})
-
-describe('normalizeBboxForDisplay', () => {
-  it('adds ~10m padding to non-degenerate bbox', () => {
-    const bbox = [-122.5, 37.7, -122.4, 37.8] as [number, number, number, number]
-    const result = normalizeBboxForDisplay(bbox)
-    expect(result[0]).toBeLessThan(-122.5)
-    expect(result[1]).toBeLessThan(37.7)
-    expect(result[2]).toBeGreaterThan(-122.4)
-    expect(result[3]).toBeGreaterThan(37.8)
-  })
-
-  it('pads fully degenerate bbox (single point)', () => {
-    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
-    const result = normalizeBboxForDisplay(bbox)
-    expect(result[0]).toBeLessThan(-1.572)
-    expect(result[2]).toBeGreaterThan(-1.572)
-    expect(result[1]).toBeLessThan(43.457)
-    expect(result[3]).toBeGreaterThan(43.457)
-  })
-
-  it('applies exact display padding of 0.0001', () => {
-    const bbox = [0, 0, 10, 10] as [number, number, number, number]
-    expect(normalizeBboxForDisplay(bbox)).toEqual([-0.0001, -0.0001, 10.0001, 10.0001])
-  })
-
-  it('applies smaller padding than clipping variant', () => {
-    const bbox = [0, 0, 0, 0] as [number, number, number, number]
-    const clipping = normalizeBboxForClipping(bbox)
-    const display = normalizeBboxForDisplay(bbox)
-    expect(Math.abs(display[0])).toBeLessThan(Math.abs(clipping[0]))
   })
 })


### PR DESCRIPTION
## Release v0.4.6

### Fixes
* fix: reduce bbox layer size for degenerate bboxes (point/line) by @wazolab
* fix: table cell overflow in Firefox in LoChaDiff by @wazolab
* fix: table overflows parent in LoChaDiff with long values by @wazolab
* fix: restore normalized bbox for non-degenerate bbox layer display by @wazolab

### Refactoring
* refactor: simplify bbox rendering pipeline in VMap by @wazolab

### Styles
* style: adjust bbox layer dash pattern and offset by @wazolab
* style: use lightgrey border on VMap by @wazolab
* style: remove background color from before/after blocks by @wazolab
* style: remove padding on locha when single group by @wazolab

### Tests
* test: add tests for normalizeBboxForBboxLayer by @wazolab

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.4.6