### PR TITLE
feat: simplify before/after display for single-object groups

### DIFF
--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -33,6 +33,12 @@ const { loCha, getBeforeFeatures, getAfterFeatures } = inject(LOCHA_KEY)!
 if (!loCha.value)
   throw new Error('LoCha is empty.')
 
+const beforeFeatures = computed(() => getBeforeFeatures(props.features))
+const afterFeatures = computed(() => getAfterFeatures(props.features))
+const isSingleDelete = computed(() => beforeFeatures.value.length > 0 && afterFeatures.value.length === 0)
+const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFeatures.value.length > 0)
+const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1)
+
 const groupNameParts = computed(() => {
   const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
   const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
@@ -76,10 +82,10 @@ const groupNameTitle = computed(() => {
       <div v-if="$slots['content-start']" class="content-start">
         <slot name="content-start" :index="index" />
       </div>
-      <div class="before-list">
+      <div v-if="!isSingleUpdate" class="before-list" :class="{ 'list--wide': isSingleDelete }">
         <ul>
           <li
-            v-for="feature in getBeforeFeatures(features)"
+            v-for="feature in beforeFeatures"
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
@@ -90,10 +96,11 @@ const groupNameTitle = computed(() => {
           </li>
         </ul>
       </div>
-      <div class="after-list">
+      <div class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
+        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]" :compact="true" />
         <ul>
           <li
-            v-for="feature in getAfterFeatures(features)"
+            v-for="feature in afterFeatures"
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
@@ -186,6 +193,10 @@ const groupNameTitle = computed(() => {
   display: flex;
   align-items: center;
   gap: 0.3em;
+}
+
+.list--wide {
+  grid-column: span 2;
 }
 
 .v-map {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -40,8 +40,8 @@ const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFea
 const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1)
 
 const groupNameParts = computed(() => {
-  const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
-  const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+  const beforeNames = [...new Set(beforeFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
+  const afterNames = [...new Set(afterFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
 
   const before = beforeNames.length > 0 ? beforeNames.join(', ') : null
   const after = afterNames.length > 0 ? afterNames.join(', ') : null
@@ -82,7 +82,7 @@ const groupNameTitle = computed(() => {
       <div v-if="$slots['content-start']" class="content-start">
         <slot name="content-start" :index="index" />
       </div>
-      <div v-if="!isSingleUpdate" class="before-list" :class="{ 'list--wide': isSingleDelete }">
+      <div v-if="!isSingleUpdate && !isSingleNew" class="before-list" :class="{ 'list--wide': isSingleDelete }">
         <ul>
           <li
             v-for="feature in beforeFeatures"
@@ -96,8 +96,8 @@ const groupNameTitle = computed(() => {
           </li>
         </ul>
       </div>
-      <div class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
-        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]" :compact="true" />
+      <div v-if="!isSingleDelete" class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
+        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]!" :compact="true" />
         <ul>
           <li
             v-for="feature in afterFeatures"

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -8,6 +8,7 @@ import { getDeepHistoryUrl, getJosmUrl, getOsmHistoryUrl, getOsmHistoryViewerUrl
 const props = defineProps<{
   feature: IFeature
   josmTarget?: string
+  compact?: boolean
 }>()
 
 defineSlots<{ 'object-detail'?: () => void }>()
@@ -43,7 +44,7 @@ const color = computed(() => loChaColors[status.value])
           {{ `${feature.properties.objtype}${feature.properties.id}-v${feature.properties.version}` }}
         </a>
         <div
-          v-if="status === 'new' || status === 'delete'"
+          v-if="!compact && (status === 'new' || status === 'delete')"
           class="status-content"
           :class="{
             'object-new': status === 'new',
@@ -52,7 +53,7 @@ const color = computed(() => loChaColors[status.value])
         >
           {{ statusContent }}
         </div>
-        <div class="fab">
+        <div v-if="!compact" class="fab">
           <button class="fab-toggle" type="button" title="Tools">
             🔧 Tools
           </button>
@@ -109,7 +110,7 @@ const color = computed(() => loChaColors[status.value])
         👤{{ feature.properties.username }}
       </a>
     </header>
-    <slot name="object-detail" />
+    <slot v-if="!compact" name="object-detail" />
   </article>
 </template>
 


### PR DESCRIPTION
Closes #161

## Changes

### `LoChaObject.vue`
- New `compact` prop: hides FAB, status badge, and `object-detail` slot — shows only link, date, username

### `LoChaGroup.vue`
- Computed `isSingleDelete`, `isSingleNew`, `isSingleUpdate` from before/after feature counts
- **delete**: before block spans 2 columns (`list--wide`)
- **new**: after block spans 2 columns
- **update**: before block hidden, after block spans 2 columns with compact before metadata above the after content
- **n+n**: unchanged