### PR TITLE
Release v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/App.vue
+++ b/src/App.vue
@@ -121,10 +121,6 @@ function handleSubmit(data: FormData) {
         <template v-for="(link, i) in getLinks(feature, index)" :key="i">
           <template v-if="feature.properties.is_after">
             <template v-for="(before, _) in [getBeforeFeature(link)]" :key="_">
-              <div class="infos">
-                <span v-if="before" class="title">🔗 {{ `${before.properties.objtype}${before.properties.id}-v${before.properties.version}` }}</span>
-                <span v-if="before" class="date">📅 {{ feature.properties.created }}</span>
-              </div>
               <LoChaReason :reason="link.conflation_reason" />
               <LoChaDiff
                 v-if="!feature.properties.deleted"

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -33,6 +33,12 @@ const { loCha, getBeforeFeatures, getAfterFeatures } = inject(LOCHA_KEY)!
 if (!loCha.value)
   throw new Error('LoCha is empty.')
 
+const beforeFeatures = computed(() => getBeforeFeatures(props.features))
+const afterFeatures = computed(() => getAfterFeatures(props.features))
+const isSingleDelete = computed(() => beforeFeatures.value.length > 0 && afterFeatures.value.length === 0)
+const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFeatures.value.length > 0)
+const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1)
+
 const groupNameParts = computed(() => {
   const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
   const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
@@ -76,10 +82,10 @@ const groupNameTitle = computed(() => {
       <div v-if="$slots['content-start']" class="content-start">
         <slot name="content-start" :index="index" />
       </div>
-      <div class="before-list">
+      <div v-if="!isSingleUpdate" class="before-list" :class="{ 'list--wide': isSingleDelete }">
         <ul>
           <li
-            v-for="feature in getBeforeFeatures(features)"
+            v-for="feature in beforeFeatures"
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
@@ -90,10 +96,11 @@ const groupNameTitle = computed(() => {
           </li>
         </ul>
       </div>
-      <div class="after-list">
+      <div class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
+        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]" :compact="true" />
         <ul>
           <li
-            v-for="feature in getAfterFeatures(features)"
+            v-for="feature in afterFeatures"
             :key="feature.id"
           >
             <LoChaObject :feature="feature" :josm-target="josmTarget">
@@ -186,6 +193,10 @@ const groupNameTitle = computed(() => {
   display: flex;
   align-items: center;
   gap: 0.3em;
+}
+
+.list--wide {
+  grid-column: span 2;
 }
 
 .v-map {

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -40,8 +40,8 @@ const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFea
 const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1)
 
 const groupNameParts = computed(() => {
-  const beforeNames = [...new Set(getBeforeFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
-  const afterNames = [...new Set(getAfterFeatures(props.features).map(f => f.properties.tags?.name).filter(Boolean))]
+  const beforeNames = [...new Set(beforeFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
+  const afterNames = [...new Set(afterFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
 
   const before = beforeNames.length > 0 ? beforeNames.join(', ') : null
   const after = afterNames.length > 0 ? afterNames.join(', ') : null
@@ -82,7 +82,7 @@ const groupNameTitle = computed(() => {
       <div v-if="$slots['content-start']" class="content-start">
         <slot name="content-start" :index="index" />
       </div>
-      <div v-if="!isSingleUpdate" class="before-list" :class="{ 'list--wide': isSingleDelete }">
+      <div v-if="!isSingleUpdate && !isSingleNew" class="before-list" :class="{ 'list--wide': isSingleDelete }">
         <ul>
           <li
             v-for="feature in beforeFeatures"
@@ -96,8 +96,8 @@ const groupNameTitle = computed(() => {
           </li>
         </ul>
       </div>
-      <div class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
-        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]" :compact="true" />
+      <div v-if="!isSingleDelete" class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
+        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]!" :compact="true" />
         <ul>
           <li
             v-for="feature in afterFeatures"

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -37,7 +37,8 @@ const beforeFeatures = computed(() => getBeforeFeatures(props.features))
 const afterFeatures = computed(() => getAfterFeatures(props.features))
 const isSingleDelete = computed(() => beforeFeatures.value.length > 0 && afterFeatures.value.length === 0)
 const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFeatures.value.length > 0)
-const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1)
+const isSingleDeletedUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !!afterFeatures.value[0]?.properties.deleted)
+const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !afterFeatures.value[0]?.properties.deleted)
 
 const groupNameParts = computed(() => {
   const beforeNames = [...new Set(beforeFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
@@ -82,7 +83,7 @@ const groupNameTitle = computed(() => {
       <div v-if="$slots['content-start']" class="content-start">
         <slot name="content-start" :index="index" />
       </div>
-      <div v-if="!isSingleUpdate && !isSingleNew" class="before-list" :class="{ 'list--wide': isSingleDelete }">
+      <div v-if="!isSingleUpdate && !isSingleNew && !isSingleDeletedUpdate" class="before-list" :class="{ 'list--wide': isSingleDelete }">
         <ul>
           <li
             v-for="feature in beforeFeatures"
@@ -96,19 +97,41 @@ const groupNameTitle = computed(() => {
           </li>
         </ul>
       </div>
-      <div v-if="!isSingleDelete" class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate }">
-        <LoChaObject v-if="isSingleUpdate" :feature="beforeFeatures[0]!" :compact="true" />
+      <div v-if="!isSingleDelete" class="after-list" :class="{ 'list--wide': isSingleNew || isSingleUpdate || isSingleDeletedUpdate }">
         <ul>
-          <li
-            v-for="feature in afterFeatures"
-            :key="feature.id"
-          >
-            <LoChaObject :feature="feature" :josm-target="josmTarget">
-              <template v-if="$slots['object-detail']" #object-detail>
-                <slot name="object-detail" :feature="feature" :index="index" />
-              </template>
-            </LoChaObject>
-          </li>
+          <template v-if="isSingleDeletedUpdate">
+            <li>
+              <LoChaObject :feature="afterFeatures[0]!" :josm-target="josmTarget">
+                <template #object-detail>
+                  <slot name="object-detail" :feature="beforeFeatures[0]!" :index="index" />
+                </template>
+              </LoChaObject>
+            </li>
+          </template>
+          <template v-else-if="isSingleUpdate">
+            <li>
+              <LoChaObject :feature="afterFeatures[0]!" :josm-target="josmTarget">
+                <template #before>
+                  <LoChaObject :feature="beforeFeatures[0]!" :compact="true" />
+                </template>
+                <template #object-detail>
+                  <slot name="object-detail" :feature="afterFeatures[0]!" :index="index" />
+                </template>
+              </LoChaObject>
+            </li>
+          </template>
+          <template v-else>
+            <li
+              v-for="feature in afterFeatures"
+              :key="feature.id"
+            >
+              <LoChaObject :feature="feature" :josm-target="josmTarget">
+                <template v-if="$slots['object-detail']" #object-detail>
+                  <slot name="object-detail" :feature="feature" :index="index" />
+                </template>
+              </LoChaObject>
+            </li>
+          </template>
         </ul>
       </div>
       <VMap :id="`${instanceId}-${props.index}`" :features="features" :bbox="loCha?.bbox" />

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -11,7 +11,10 @@ const props = defineProps<{
   compact?: boolean
 }>()
 
-defineSlots<{ 'object-detail'?: () => void }>()
+defineSlots<{
+  'before'?: () => void
+  'object-detail'?: () => void
+}>()
 
 const { getStatus } = inject(LOCHA_KEY)!
 
@@ -33,83 +36,91 @@ const color = computed(() => loChaColors[status.value])
 
 <template>
   <article class="locha-object">
-    <header>
-      <div class="wrap">
+    <div class="header-row">
+      <template v-if="$slots.before">
+        <div class="before-content">
+          <slot name="before" />
+        </div>
+        <span class="header-arrow">→</span>
+      </template>
+      <header>
+        <div class="wrap">
+          <a
+            :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
+            title="OSM History"
+            target="_blank"
+            @click.stop
+          >
+            {{ `${feature.properties.objtype}${feature.properties.id}-v${feature.properties.version}` }}
+          </a>
+          <div
+            v-if="!compact && (status === 'new' || status === 'delete')"
+            class="status-content"
+            :class="{
+              'object-new': status === 'new',
+              'object-deleted': status === 'delete',
+            }"
+          >
+            {{ statusContent }}
+          </div>
+          <div v-if="!compact" class="fab">
+            <button class="fab-toggle" type="button" title="Tools">
+              🔧 Tools
+            </button>
+            <div class="fab-menu">
+              <a
+                :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
+                class="action-btn"
+                title="Edit in OSM iD"
+                target="_blank"
+                @click.stop
+              >
+                OSM iD
+              </a>
+              <a
+                :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
+                class="action-btn"
+                title="Edit in JOSM"
+                :target="josmTarget || 'hidden_josm_target'"
+                @click.stop
+              >
+                JOSM
+              </a>
+              <a
+                :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
+                class="action-btn"
+                title="OSM Deep History"
+                target="_blank"
+                @click.stop
+              >
+                Deep H
+              </a>
+              <a
+                :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
+                class="action-btn"
+                title="OSM History Viewer"
+                target="_blank"
+                @click.stop
+              >
+                OSM H
+              </a>
+            </div>
+          </div>
+        </div>
+        <p class="date">
+          📅 {{ props.feature.properties.created }}
+        </p>
         <a
-          :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-          title="OSM History"
+          v-if="feature.properties.username"
+          :href="getOsmUserUrl(feature.properties.username)"
+          :title="`View ${feature.properties.username} OSM profile`"
           target="_blank"
           @click.stop
         >
-          {{ `${feature.properties.objtype}${feature.properties.id}-v${feature.properties.version}` }}
+          👤{{ feature.properties.username }}
         </a>
-        <div
-          v-if="!compact && (status === 'new' || status === 'delete')"
-          class="status-content"
-          :class="{
-            'object-new': status === 'new',
-            'object-deleted': status === 'delete',
-          }"
-        >
-          {{ statusContent }}
-        </div>
-        <div v-if="!compact" class="fab">
-          <button class="fab-toggle" type="button" title="Tools">
-            🔧 Tools
-          </button>
-          <div class="fab-menu">
-            <a
-              :href="getOsmHistoryUrl(feature.properties.objtype, feature.properties.id)"
-              class="action-btn"
-              title="Edit in OSM iD"
-              target="_blank"
-              @click.stop
-            >
-              OSM iD
-            </a>
-            <a
-              :href="getJosmUrl(feature.properties.objtype, feature.properties.id)"
-              class="action-btn"
-              title="Edit in JOSM"
-              :target="josmTarget || 'hidden_josm_target'"
-              @click.stop
-            >
-              JOSM
-            </a>
-            <a
-              :href="getDeepHistoryUrl(feature.properties.objtype, feature.properties.id)"
-              class="action-btn"
-              title="OSM Deep History"
-              target="_blank"
-              @click.stop
-            >
-              Deep H
-            </a>
-            <a
-              :href="getOsmHistoryViewerUrl(feature.properties.objtype, feature.properties.id)"
-              class="action-btn"
-              title="OSM History Viewer"
-              target="_blank"
-              @click.stop
-            >
-              OSM H
-            </a>
-          </div>
-        </div>
-      </div>
-      <p class="date">
-        📅 {{ props.feature.properties.created }}
-      </p>
-      <a
-        v-if="feature.properties.username"
-        :href="getOsmUserUrl(feature.properties.username)"
-        :title="`View ${feature.properties.username} OSM profile`"
-        target="_blank"
-        @click.stop
-      >
-        👤{{ feature.properties.username }}
-      </a>
-    </header>
+      </header>
+    </div>
     <slot v-if="!compact" name="object-detail" />
   </article>
 </template>
@@ -121,6 +132,33 @@ article {
   flex-direction: column;
   gap: 4px;
   padding: 0.25rem;
+}
+
+.header-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.before-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.before-content :deep(article) {
+  border: none;
+  padding: 0;
+}
+
+.header-arrow {
+  align-self: center;
+  flex-shrink: 0;
+  color: #666;
+}
+
+header {
+  flex: 1;
+  min-width: 0;
 }
 
 header > a {

--- a/src/components/LoCha/LoChaObject.vue
+++ b/src/components/LoCha/LoChaObject.vue
@@ -8,6 +8,7 @@ import { getDeepHistoryUrl, getJosmUrl, getOsmHistoryUrl, getOsmHistoryViewerUrl
 const props = defineProps<{
   feature: IFeature
   josmTarget?: string
+  compact?: boolean
 }>()
 
 defineSlots<{ 'object-detail'?: () => void }>()
@@ -43,7 +44,7 @@ const color = computed(() => loChaColors[status.value])
           {{ `${feature.properties.objtype}${feature.properties.id}-v${feature.properties.version}` }}
         </a>
         <div
-          v-if="status === 'new' || status === 'delete'"
+          v-if="!compact && (status === 'new' || status === 'delete')"
           class="status-content"
           :class="{
             'object-new': status === 'new',
@@ -52,7 +53,7 @@ const color = computed(() => loChaColors[status.value])
         >
           {{ statusContent }}
         </div>
-        <div class="fab">
+        <div v-if="!compact" class="fab">
           <button class="fab-toggle" type="button" title="Tools">
             🔧 Tools
           </button>
@@ -109,7 +110,7 @@ const color = computed(() => loChaColors[status.value])
         👤{{ feature.properties.username }}
       </a>
     </header>
-    <slot name="object-detail" />
+    <slot v-if="!compact" name="object-detail" />
   </article>
 </template>
 

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -10,7 +10,7 @@ import { inject, shallowRef, watch } from 'vue'
 import { MAP_STYLE_URL_KEY } from '@/constants/injectionKeys'
 import { MAP_STYLE_URL } from '@/constants/map'
 import { BBOX_SOURCE_ID, LAYERS, SOURCE_ID } from '@/constants/mapLayers'
-import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping } from '@/utils/geom'
+import { clipAndEnvelope, isBboxDegenerate, normalizeBboxForClipping } from '@/utils/geom'
 import { OBJTYPE_FULL } from '@/utils/osm-links'
 import 'maplibre-gl/dist/maplibre-gl.css'
 
@@ -124,8 +124,8 @@ function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
 
-  if (normalizedBbox) {
-    displayBbox(normalizeBboxForBboxLayer(props.bbox!))
+  if (props.bbox && !isBboxDegenerate(props.bbox)) {
+    displayBbox(props.bbox as [number, number, number, number])
   }
 
   map.value!.addSource(SOURCE_ID, {

--- a/src/utils/geom.ts
+++ b/src/utils/geom.ts
@@ -49,9 +49,6 @@ export function clipAndEnvelope(
 // ~100m padding in degrees, ensures features on bbox edges are not excluded during clipping
 const CLIPPING_PADDING = 0.001
 
-// Minimal expansion for degenerate bboxes (point/line), visual padding comes from fitBounds padding
-const DEGENERATE_BBOX_PADDING = 0.00001
-
 function padBbox(bbox: GeoJSON.BBox, padding: number): [number, number, number, number] {
   return [
     bbox[0] - padding,
@@ -65,7 +62,6 @@ export function normalizeBboxForClipping(bbox: GeoJSON.BBox): [number, number, n
   return padBbox(bbox, CLIPPING_PADDING)
 }
 
-export function normalizeBboxForBboxLayer(bbox: GeoJSON.BBox): [number, number, number, number] {
-  const isDegenerate = bbox[0] === bbox[2] || bbox[1] === bbox[3]
-  return isDegenerate ? padBbox(bbox, DEGENERATE_BBOX_PADDING) : (bbox as [number, number, number, number])
+export function isBboxDegenerate(bbox: GeoJSON.BBox): boolean {
+  return bbox[0] === bbox[2] || bbox[1] === bbox[3]
 }

--- a/tests/utils/geom.spec.ts
+++ b/tests/utils/geom.spec.ts
@@ -1,6 +1,6 @@
 import type { BBox } from 'geojson'
 import { describe, expect, it } from 'vitest'
-import { clipAndEnvelope, normalizeBboxForBboxLayer, normalizeBboxForClipping } from '@/utils/geom'
+import { clipAndEnvelope, isBboxDegenerate, normalizeBboxForClipping } from '@/utils/geom'
 
 describe('clipAndEnvelope', () => {
   const bbox: BBox = [-1, -1, 10, 10]
@@ -121,30 +121,20 @@ describe('normalizeBboxForClipping', () => {
   })
 })
 
-describe('normalizeBboxForBboxLayer', () => {
-  it('returns bbox as-is for non-degenerate bbox', () => {
-    const bbox = [0, 0, 10, 10] as [number, number, number, number]
-    expect(normalizeBboxForBboxLayer(bbox)).toEqual([0, 0, 10, 10])
+describe('isBboxDegenerate', () => {
+  it('returns false for non-degenerate bbox', () => {
+    expect(isBboxDegenerate([0, 0, 10, 10])).toBe(false)
   })
 
-  it('expands fully degenerate bbox (single point)', () => {
-    const bbox = [-1.572, 43.457, -1.572, 43.457] as [number, number, number, number]
-    const result = normalizeBboxForBboxLayer(bbox)
-    expect(result[0]).toBeLessThan(-1.572)
-    expect(result[2]).toBeGreaterThan(-1.572)
-    expect(result[1]).toBeLessThan(43.457)
-    expect(result[3]).toBeGreaterThan(43.457)
+  it('returns true for fully degenerate bbox (single point)', () => {
+    expect(isBboxDegenerate([-1.572, 43.457, -1.572, 43.457])).toBe(true)
   })
 
-  it('expands degenerate bbox with zero width (vertical line)', () => {
-    const bbox = [2.0, 48.0, 2.0, 48.5] as [number, number, number, number]
-    const result = normalizeBboxForBboxLayer(bbox)
-    expect(result[0]).toBeLessThan(2.0)
-    expect(result[2]).toBeGreaterThan(2.0)
+  it('returns true for degenerate bbox with zero width (vertical line)', () => {
+    expect(isBboxDegenerate([2.0, 48.0, 2.0, 48.5])).toBe(true)
   })
 
-  it('applies minimal expansion of 0.00001 on degenerate bbox', () => {
-    const bbox = [0, 0, 0, 0] as [number, number, number, number]
-    expect(normalizeBboxForBboxLayer(bbox)).toEqual([-0.00001, -0.00001, 0.00001, 0.00001])
+  it('returns true for degenerate bbox with zero height (horizontal line)', () => {
+    expect(isBboxDegenerate([0, 5, 10, 5])).toBe(true)
   })
 })


### PR DESCRIPTION
### Features
* feat: simplify before/after display for single-object groups by @wazolab
* feat: show isSingleUpdate and isSingleDeletedUpdate in a single block by @wazolab

### Fixes
* fix: skip bbox display for degenerate bboxes (points) by @wazolab
* fix: hide empty before/after lists and reuse computed features in groupNameParts by @wazolab

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.5.0