### PR TITLE
ci: fix concurrency group to prevent tag push from cancelling branch deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
 
 # Allow only one concurrent deployment at a time
 concurrency:
-  group: pages # Group deployments by name for concurrency control
-  cancel-in-progress: true # Cancel any in-progress deployments if a new one starts
+  group: ${{ github.ref }} # Group by ref so tag pushes don't cancel branch runs
+  cancel-in-progress: true # Cancel any in-progress run for the same ref
 
 jobs:
   # Setup environment and dependencies


### PR DESCRIPTION
## Summary

- Fix the CI concurrency group from hardcoded `pages` to `\${{ github.ref }}` so that a tag push no longer cancels an in-progress branch deploy
- This was causing the deploy job to be skipped on every release (tag push cancelled the `main` branch run)

## Test plan

- [ ] Merge this PR into `main`
- [ ] Verify the deploy job completes successfully on the resulting push to `main`