### PR TITLE
Release 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/App.vue
+++ b/src/App.vue
@@ -121,6 +121,9 @@ function handleSubmit(data: FormData) {
         <template v-for="(link, i) in getLinks(feature, index)" :key="i">
           <template v-if="feature.properties.is_after">
             <template v-for="(before, _) in [getBeforeFeature(link)]" :key="_">
+              <span v-if="before && geojson!.metadata.links[index].length > 1" class="before-link">
+                🔗 {{ `${before.properties.objtype}${before.properties.id}-v${before.properties.version}` }}
+              </span>
               <LoChaDiff
                 v-if="!feature.properties.deleted"
                 :diff="link.diff_tags"
@@ -175,5 +178,10 @@ aside {
 
 .locha {
   grid-column: 2;
+}
+
+.before-link {
+  font-size: 0.75em;
+  color: #888;
 }
 </style>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -175,28 +175,12 @@ const groupNameTitle = computed(() => {
   margin: 0;
   font-size: 1rem;
   font-weight: 500;
-  display: flex;
-  align-items: center;
-  overflow: hidden;
   min-width: 0;
-}
-
-.name-before {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  flex-shrink: 1;
-  min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .name-separator {
-  flex-shrink: 0;
   white-space: nowrap;
-}
-
-.name-after {
-  white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .anchor-button {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -38,6 +38,7 @@ const isVisible = shallowRef(false)
 const popup = shallowRef<maplibre.Popup>()
 const hoveredStateFeature = shallowRef<maplibre.MapGeoJSONFeature>()
 let normalizedBbox: [number, number, number, number] | undefined
+let initialBounds: [[number, number], [number, number]] | undefined
 
 watch(isVisible, (newState) => {
   if (newState) {
@@ -70,7 +71,7 @@ function initMap() {
     if (clipped) {
       const boundsArray = normalizedBbox ?? turfBbox(clipped) as [number, number, number, number]
 
-      const bounds: [[number, number], [number, number]] = [
+      initialBounds = [
         [boundsArray[0], boundsArray[1]],
         [boundsArray[2], boundsArray[3]],
       ]
@@ -78,12 +79,6 @@ function initMap() {
       map.value = new maplibre.Map({
         hash: false,
         container: `map-${props.id}`,
-        bounds,
-        fitBoundsOptions: {
-          padding: paddingOptions,
-          animate: false,
-          maxZoom: 17,
-        },
         style: mapStyleUrl,
         cooperativeGestures: true,
         attributionControl: false,
@@ -123,6 +118,15 @@ function displayBbox(bbox: BBox): void {
 function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
+
+  map.value.resize()
+  if (initialBounds) {
+    map.value.fitBounds(initialBounds, {
+      padding: paddingOptions,
+      animate: false,
+      maxZoom: 17,
+    })
+  }
 
   if (props.bbox) {
     const bbox = isBboxDegenerate(props.bbox)

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -68,7 +68,7 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = turfBbox(clipped) as [number, number, number, number]
+      const boundsArray = normalizedBbox ?? turfBbox(clipped) as [number, number, number, number]
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],

--- a/src/constants/mapLayers.ts
+++ b/src/constants/mapLayers.ts
@@ -12,10 +12,14 @@ export const LAYERS = {
     id: 'bbox-layer',
     type: 'line',
     source: BBOX_SOURCE_ID,
+    layout: {
+      'line-join': 'miter',
+    },
     paint: {
       'line-color': '#000000',
       'line-width': 1,
       'line-dasharray': [2, 2],
+      'line-offset': -32,
     },
   },
   PolygonBorder: {


### PR DESCRIPTION
### Fixes

* fix: center VMap on query bbox rather than computed clipped envelope by @wazolab
* fix: display full group names with wrapping instead of truncation by @wazolab
* fix: show before object link in after cards for multi-object groups by @wazolab
* fix: resize map before fitBounds to fix viewport on mobile by @wazolab

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.5.2