### PR TITLE
Release v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,7 +141,7 @@ function handleSubmit(data: FormData) {
           </template>
           <template v-else>
             <LoChaDiff
-              :diff="link.diff_tags"
+              v-if="!link.after"
               :src="feature.properties"
             />
           </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -162,9 +162,10 @@ main {
 .locha-header {
   grid-column: 2;
   grid-row: 1;
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 1rem;
-  padding: 0.75rem 1rem;
+  padding: 0.75rem 0.5rem;
   background: linear-gradient(to bottom, #e8e8ea, #f0f0f2);
   border-bottom: 1px solid #d0d0d2;
 }
@@ -174,7 +175,6 @@ aside {
 }
 
 .locha-header h2 {
-  flex: 1;
   text-align: center;
   margin: 0;
   font-size: 1rem;

--- a/src/App.vue
+++ b/src/App.vue
@@ -141,7 +141,6 @@ function handleSubmit(data: FormData) {
           </template>
           <template v-else>
             <LoChaDiff
-              v-if="!link.after"
               :src="feature.properties"
             />
           </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -133,6 +133,12 @@ function handleSubmit(data: FormData) {
               <LoChaReason :reason="link.conflation_reason" />
             </template>
           </template>
+          <template v-else-if="feature.properties.is_new">
+            <LoChaDiff
+              :diff="link.diff_tags"
+              :dst="feature.properties"
+            />
+          </template>
           <template v-else>
             <LoChaDiff
               :diff="link.diff_tags"

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,8 +113,8 @@ function handleSubmit(data: FormData) {
       @submit="handleSubmit"
     />
     <div v-if="dateFrom || dateTo" class="locha-header">
-      <h2>Before : {{ dateFrom }}</h2>
-      <h2>After : {{ dateTo }}</h2>
+      <h2>From : {{ dateFrom }}</h2>
+      <h2>To : {{ dateTo }}</h2>
     </div>
     <LoCha id="demo" :data="geojson" :reason-collapsed="false">
       <template #object-detail="{ feature, index }">

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -35,6 +35,7 @@ const {
   featureCount,
   groups,
   setLoCha,
+  resetLoCha,
 } = loChaInstance
 
 const isSingle = computed(() => groups.value.length === 1)
@@ -42,6 +43,9 @@ const isSingle = computed(() => groups.value.length === 1)
 watch(() => props.data, (newValue) => {
   if (newValue) {
     setLoCha(newValue)
+  }
+  else {
+    resetLoCha()
   }
 }, { immediate: true })
 </script>

--- a/src/components/LoCha/LoChaDiff.vue
+++ b/src/components/LoCha/LoChaDiff.vue
@@ -21,9 +21,6 @@ const props = withDefaults(
 )
 
 const groupedTagKeys = computed((): string[][] => {
-  if (props.src && !props.dst)
-    return [Object.keys(props.src.tags)]
-
   const keys: string[] = sortBy(
     uniq([
       ...Object.keys(props.src?.tags || {}),
@@ -49,32 +46,25 @@ const groupedTagKeys = computed((): string[][] => {
 })
 
 function actionIcon(key: string): string | undefined {
-  if (props.src && !props.dst)
-    return undefined
-
   return (
     props.diff?.[key]
     && (
       !props.src?.tags || !(key in props.src.tags)
         ? '➕'
-        : props.dst && !props.dst.tags[key]
-          ? '✖'
-          : '~')
+        : !props.dst || !props.dst.tags[key]
+            ? '✖'
+            : '~')
   )
 }
 
 function backgroundClass(key: string): string | undefined {
-  if (props.src && !props.dst) {
-    return undefined
-  }
-
   return (
     props.diff?.[key]
     && (!props.src?.tags || !(key in props.src.tags)
       ? 'attribute-new'
-      : props.dst && !props.dst.tags[key]
-        ? 'attribute-deleted'
-        : 'attribute-changed')
+      : !props.dst || !props.dst.tags[key]
+          ? 'attribute-deleted'
+          : 'attribute-changed')
   )
 }
 
@@ -86,8 +76,6 @@ function isRejected(key: string): boolean {
 }
 
 function getRowClass(key: string): string | undefined {
-  if (props.src && !props.dst)
-    return 'no_changes'
   return isRejected(key) ? undefined : 'no_changes'
 }
 

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { GroupSlotProps, LoChaGroup, ObjectDetailSlotProps } from '@/types'
+import type { GroupSlotProps, IFeature, LoChaGroup, ObjectDetailSlotProps } from '@/types'
 import { computed, inject, useSlots } from 'vue'
 import LoChaObject from '@/components/LoCha/LoChaObject.vue'
 import VMap from '@/components/VMap.vue'

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -43,14 +43,18 @@ const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFea
 const isSingleDeletedUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !!afterFeatures.value[0]?.properties.deleted)
 const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !afterFeatures.value[0]?.properties.deleted)
 
-function getBeforeFeaturesForAfter(afterFeature: IFeature): IFeature[] {
+const beforeFeaturesPerAfter = computed((): Map<string | number, IFeature[]> => {
   const links = loCha.value?.metadata.links[props.index] ?? []
-  const beforeIds = links
-    .filter(link => link.after === afterFeature.id)
-    .map(link => link.before)
-    .filter(Boolean)
-  return props.features.filter(f => beforeIds.includes(f.id as string))
-}
+  return new Map(
+    afterFeatures.value.map((afterFeature) => {
+      const beforeIds = links
+        .filter(link => link.after === afterFeature.id)
+        .map(link => link.before)
+        .filter(Boolean)
+      return [afterFeature.id as string | number, props.features.filter(f => beforeIds.includes(f.id as string))]
+    }),
+  )
+})
 
 const groupNameParts = computed(() => {
   const beforeNames = [...new Set(beforeFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
@@ -138,9 +142,9 @@ const groupNameTitle = computed(() => {
               :key="feature.id"
             >
               <LoChaObject :feature="feature" :josm-target="josmTarget">
-                <template v-if="getBeforeFeaturesForAfter(feature).length" #before>
+                <template v-if="beforeFeaturesPerAfter.get(feature.id)?.length" #before>
                   <LoChaObject
-                    v-for="beforeFeature in getBeforeFeaturesForAfter(feature)"
+                    v-for="beforeFeature in beforeFeaturesPerAfter.get(feature.id)"
                     :key="beforeFeature.id"
                     :feature="beforeFeature"
                     :compact="true"

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -43,6 +43,15 @@ const isSingleNew = computed(() => beforeFeatures.value.length === 0 && afterFea
 const isSingleDeletedUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !!afterFeatures.value[0]?.properties.deleted)
 const isSingleUpdate = computed(() => beforeFeatures.value.length === 1 && afterFeatures.value.length === 1 && !afterFeatures.value[0]?.properties.deleted)
 
+function getBeforeFeaturesForAfter(afterFeature: IFeature): IFeature[] {
+  const links = loCha.value?.metadata.links[props.index] ?? []
+  const beforeIds = links
+    .filter(link => link.after === afterFeature.id)
+    .map(link => link.before)
+    .filter(Boolean)
+  return props.features.filter(f => beforeIds.includes(f.id as string))
+}
+
 const groupNameParts = computed(() => {
   const beforeNames = [...new Set(beforeFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
   const afterNames = [...new Set(afterFeatures.value.map(f => f.properties.tags?.name).filter(Boolean))]
@@ -129,6 +138,14 @@ const groupNameTitle = computed(() => {
               :key="feature.id"
             >
               <LoChaObject :feature="feature" :josm-target="josmTarget">
+                <template v-if="getBeforeFeaturesForAfter(feature).length" #before>
+                  <LoChaObject
+                    v-for="beforeFeature in getBeforeFeaturesForAfter(feature)"
+                    :key="beforeFeature.id"
+                    :feature="beforeFeature"
+                    :compact="true"
+                  />
+                </template>
                 <template v-if="$slots['object-detail']" #object-detail>
                   <slot name="object-detail" :feature="feature" :index="index" />
                 </template>

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -219,6 +219,7 @@ const groupNameTitle = computed(() => {
 .header-end {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 0.3em;
 }
 

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -22,6 +22,14 @@ const instanceId = inject(LOCHA_INSTANCE_ID_KEY)!
 const highlightBorderColor = loChaColors.delete
 const currentHash = ref<string>()
 const listRef = useTemplateRef<HTMLElement>('listRef')
+const scrollRef = useTemplateRef<HTMLElement>('scrollRef')
+
+watch(groups, () => {
+  nextTick(() => {
+    if (scrollRef.value)
+      scrollRef.value.scrollTop = 0
+  })
+})
 
 function groupId(index: number): string {
   return `locha-${instanceId}-group-${index}`
@@ -87,7 +95,7 @@ onUnmounted(() => {
 
 <template>
   <div ref="listRef" class="locha-group-list">
-    <ul>
+    <ul ref="scrollRef">
       <li v-for="(group, index) in groups" :key="index" :class="{ selected: currentHash === `#${groupId(index)}` }">
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()" @navigate="navigateToHash">
           <template v-if="$slots['object-detail']" #object-detail="slotProps">

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -90,7 +90,7 @@ function initMap() {
       // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
       // small query bboxes, causing clipped endpoints to fall outside the original bbox.
       const b = props.bbox
-      const boundsArray: [number, number, number, number] = b
+      let boundsArray: [number, number, number, number] = b
         ? [
             Math.max(rawBounds[0], b[0]),
             Math.max(rawBounds[1], b[1]),
@@ -98,6 +98,8 @@ function initMap() {
             Math.min(rawBounds[3], b[3]),
           ]
         : rawBounds
+      if (boundsArray[0] > boundsArray[2] || boundsArray[1] > boundsArray[3])
+        boundsArray = rawBounds
 
       const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -71,12 +71,21 @@ function initMap() {
 
     normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
 
+    const geoFeatures = props.features.filter(f => f.geometry != null)
+    if (!geoFeatures.length)
+      return
+
     const clipped = normalizedBbox
-      ? clipAndEnvelope(props.features, normalizedBbox)
-      : turfFeatureCollection(props.features)
+      ? clipAndEnvelope(geoFeatures, normalizedBbox)
+      : turfFeatureCollection(geoFeatures)
 
     if (clipped) {
-      const rawBounds = turfBbox(clipped) as [number, number, number, number]
+      let rawBounds = turfBbox(clipped) as [number, number, number, number]
+
+      // Expand degenerate bounds (single point) so MapLibre fitBounds doesn't default to world level.
+      if (isBboxDegenerate(rawBounds)) {
+        rawBounds = [rawBounds[0] - 0.0001, rawBounds[1] - 0.0001, rawBounds[2] + 0.0001, rawBounds[3] + 0.0001]
+      }
 
       // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
       // small query bboxes, causing clipped endpoints to fall outside the original bbox.

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -56,46 +56,12 @@ watch(isVisible, (newState) => {
 })
 
 watch(() => props.features, (newValue) => {
-  if (!map.value || !isVisible.value || !newValue)
-    return
-
-  const source = map.value.getSource(SOURCE_ID) as maplibre.GeoJSONSource
-  if (!source) {
+  if (map.value && isVisible.value && newValue) {
     map.value.remove()
     map.value = undefined
     initMap()
-    return
   }
-
-  source.setData({ type: 'FeatureCollection', features: newValue })
 })
-
-function computeBounds(features: LoChaGroup): [[number, number], [number, number]] | undefined {
-  normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
-
-  const clipped = normalizedBbox
-    ? clipAndEnvelope(features, normalizedBbox)
-    : turfFeatureCollection(features)
-
-  if (!clipped)
-    return undefined
-
-  const rawBounds = turfBbox(clipped) as [number, number, number, number]
-
-  // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
-  // small query bboxes, causing clipped endpoints to fall outside the original bbox.
-  const b = props.bbox
-  const boundsArray: [number, number, number, number] = b
-    ? [
-        Math.max(rawBounds[0], b[0]),
-        Math.max(rawBounds[1], b[1]),
-        Math.min(rawBounds[2], b[2]),
-        Math.min(rawBounds[3], b[3]),
-      ]
-    : rawBounds
-
-  return [[boundsArray[0], boundsArray[1]], [boundsArray[2], boundsArray[3]]]
-}
 
 function initMap() {
   if (!map.value) {
@@ -103,26 +69,49 @@ function initMap() {
     if (!container)
       return
 
-    const bounds = computeBounds(props.features)
-    if (!bounds)
-      return
+    normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
 
-    map.value = new maplibre.Map({
-      hash: false,
-      container: `map-${props.id}`,
-      bounds,
-      fitBoundsOptions: {
-        padding: getPadding(container),
-        animate: false,
-        maxZoom: 17,
-      },
-      style: mapStyleUrl,
-      cooperativeGestures: true,
-      attributionControl: false,
-    })
-    map.value.addControl(new maplibre.FullscreenControl())
+    const clipped = normalizedBbox
+      ? clipAndEnvelope(props.features, normalizedBbox)
+      : turfFeatureCollection(props.features)
 
-    map.value.on('load', handleMapOnLoad)
+    if (clipped) {
+      const rawBounds = turfBbox(clipped) as [number, number, number, number]
+
+      // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
+      // small query bboxes, causing clipped endpoints to fall outside the original bbox.
+      const b = props.bbox
+      const boundsArray: [number, number, number, number] = b
+        ? [
+            Math.max(rawBounds[0], b[0]),
+            Math.max(rawBounds[1], b[1]),
+            Math.min(rawBounds[2], b[2]),
+            Math.min(rawBounds[3], b[3]),
+          ]
+        : rawBounds
+
+      const bounds: [[number, number], [number, number]] = [
+        [boundsArray[0], boundsArray[1]],
+        [boundsArray[2], boundsArray[3]],
+      ]
+
+      map.value = new maplibre.Map({
+        hash: false,
+        container: `map-${props.id}`,
+        bounds,
+        fitBoundsOptions: {
+          padding: getPadding(container),
+          animate: false,
+          maxZoom: 17,
+        },
+        style: mapStyleUrl,
+        cooperativeGestures: true,
+        attributionControl: false,
+      })
+      map.value.addControl(new maplibre.FullscreenControl())
+
+      map.value.on('load', handleMapOnLoad)
+    }
   }
 }
 

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -69,7 +69,19 @@ function initMap() {
       : turfFeatureCollection(props.features)
 
     if (clipped) {
-      const boundsArray = normalizedBbox ?? turfBbox(clipped) as [number, number, number, number]
+      const rawBounds = turfBbox(clipped) as [number, number, number, number]
+
+      // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
+      // small query bboxes, causing clipped endpoints to fall outside the original bbox.
+      const b = props.bbox
+      const boundsArray: [number, number, number, number] = b
+        ? [
+            Math.max(rawBounds[0], b[0]),
+            Math.max(rawBounds[1], b[1]),
+            Math.min(rawBounds[2], b[2]),
+            Math.min(rawBounds[3], b[3]),
+          ]
+        : rawBounds
 
       initialBounds = [
         [boundsArray[0], boundsArray[1]],

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -26,11 +26,15 @@ type MapMouseEventWithFeatures = MapMouseEvent & {
   features?: maplibre.MapGeoJSONFeature[]
 }
 
-const paddingOptions = {
-  top: 60,
-  left: 60,
-  right: 60,
-  bottom: 80,
+function getPadding(container: HTMLElement) {
+  const w = container.offsetWidth
+  const h = container.offsetHeight
+  return {
+    top: Math.min(60, Math.floor(h * 0.15)),
+    left: Math.min(60, Math.floor(w * 0.15)),
+    right: Math.min(60, Math.floor(w * 0.15)),
+    bottom: Math.min(80, Math.floor(h * 0.20)),
+  }
 }
 
 const map = shallowRef<maplibre.Map>()
@@ -38,7 +42,6 @@ const isVisible = shallowRef(false)
 const popup = shallowRef<maplibre.Popup>()
 const hoveredStateFeature = shallowRef<maplibre.MapGeoJSONFeature>()
 let normalizedBbox: [number, number, number, number] | undefined
-let initialBounds: [[number, number], [number, number]] | undefined
 
 watch(isVisible, (newState) => {
   if (newState) {
@@ -62,6 +65,10 @@ watch(() => props.features, (newValue) => {
 
 function initMap() {
   if (!map.value) {
+    const container = document.getElementById(`map-${props.id}`)
+    if (!container)
+      return
+
     normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
 
     const clipped = normalizedBbox
@@ -83,7 +90,7 @@ function initMap() {
           ]
         : rawBounds
 
-      initialBounds = [
+      const bounds: [[number, number], [number, number]] = [
         [boundsArray[0], boundsArray[1]],
         [boundsArray[2], boundsArray[3]],
       ]
@@ -91,6 +98,12 @@ function initMap() {
       map.value = new maplibre.Map({
         hash: false,
         container: `map-${props.id}`,
+        bounds,
+        fitBoundsOptions: {
+          padding: getPadding(container),
+          animate: false,
+          maxZoom: 17,
+        },
         style: mapStyleUrl,
         cooperativeGestures: true,
         attributionControl: false,
@@ -130,15 +143,6 @@ function displayBbox(bbox: BBox): void {
 function handleMapOnLoad(): void {
   if (!map.value)
     throw new Error('Call initMap() function first.')
-
-  map.value.resize()
-  if (initialBounds) {
-    map.value.fitBounds(initialBounds, {
-      padding: paddingOptions,
-      animate: false,
-      maxZoom: 17,
-    })
-  }
 
   if (props.bbox) {
     const bbox = isBboxDegenerate(props.bbox)

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -68,7 +68,6 @@ watch(() => props.features, (newValue) => {
   }
 
   source.setData({ type: 'FeatureCollection', features: newValue })
-  refitBounds(newValue)
 })
 
 function computeBounds(features: LoChaGroup): [[number, number], [number, number]] | undefined {
@@ -96,25 +95,6 @@ function computeBounds(features: LoChaGroup): [[number, number], [number, number
     : rawBounds
 
   return [[boundsArray[0], boundsArray[1]], [boundsArray[2], boundsArray[3]]]
-}
-
-function refitBounds(features: LoChaGroup): void {
-  if (!map.value)
-    return
-
-  const bounds = computeBounds(features)
-  if (!bounds)
-    return
-
-  const container = document.getElementById(`map-${props.id}`)
-  if (!container)
-    return
-
-  map.value.fitBounds(bounds, {
-    padding: getPadding(container),
-    animate: false,
-    maxZoom: 17,
-  })
 }
 
 function initMap() {

--- a/src/components/VMap.vue
+++ b/src/components/VMap.vue
@@ -56,12 +56,66 @@ watch(isVisible, (newState) => {
 })
 
 watch(() => props.features, (newValue) => {
-  if (map.value && isVisible.value && newValue) {
+  if (!map.value || !isVisible.value || !newValue)
+    return
+
+  const source = map.value.getSource(SOURCE_ID) as maplibre.GeoJSONSource
+  if (!source) {
     map.value.remove()
     map.value = undefined
     initMap()
+    return
   }
+
+  source.setData({ type: 'FeatureCollection', features: newValue })
+  refitBounds(newValue)
 })
+
+function computeBounds(features: LoChaGroup): [[number, number], [number, number]] | undefined {
+  normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
+
+  const clipped = normalizedBbox
+    ? clipAndEnvelope(features, normalizedBbox)
+    : turfFeatureCollection(features)
+
+  if (!clipped)
+    return undefined
+
+  const rawBounds = turfBbox(clipped) as [number, number, number, number]
+
+  // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
+  // small query bboxes, causing clipped endpoints to fall outside the original bbox.
+  const b = props.bbox
+  const boundsArray: [number, number, number, number] = b
+    ? [
+        Math.max(rawBounds[0], b[0]),
+        Math.max(rawBounds[1], b[1]),
+        Math.min(rawBounds[2], b[2]),
+        Math.min(rawBounds[3], b[3]),
+      ]
+    : rawBounds
+
+  return [[boundsArray[0], boundsArray[1]], [boundsArray[2], boundsArray[3]]]
+}
+
+function refitBounds(features: LoChaGroup): void {
+  if (!map.value)
+    return
+
+  const bounds = computeBounds(features)
+  if (!bounds)
+    return
+
+  const container = document.getElementById(`map-${props.id}`)
+  if (!container)
+    return
+
+  map.value.fitBounds(bounds, {
+    padding: getPadding(container),
+    animate: false,
+    maxZoom: 17,
+  })
+}
 
 function initMap() {
   if (!map.value) {
@@ -69,49 +123,26 @@ function initMap() {
     if (!container)
       return
 
-    normalizedBbox = props.bbox ? normalizeBboxForClipping(props.bbox) : undefined
+    const bounds = computeBounds(props.features)
+    if (!bounds)
+      return
 
-    const clipped = normalizedBbox
-      ? clipAndEnvelope(props.features, normalizedBbox)
-      : turfFeatureCollection(props.features)
+    map.value = new maplibre.Map({
+      hash: false,
+      container: `map-${props.id}`,
+      bounds,
+      fitBoundsOptions: {
+        padding: getPadding(container),
+        animate: false,
+        maxZoom: 17,
+      },
+      style: mapStyleUrl,
+      cooperativeGestures: true,
+      attributionControl: false,
+    })
+    map.value.addControl(new maplibre.FullscreenControl())
 
-    if (clipped) {
-      const rawBounds = turfBbox(clipped) as [number, number, number, number]
-
-      // Clamp to original bbox: normalizedBbox adds fixed padding that can dwarf
-      // small query bboxes, causing clipped endpoints to fall outside the original bbox.
-      const b = props.bbox
-      const boundsArray: [number, number, number, number] = b
-        ? [
-            Math.max(rawBounds[0], b[0]),
-            Math.max(rawBounds[1], b[1]),
-            Math.min(rawBounds[2], b[2]),
-            Math.min(rawBounds[3], b[3]),
-          ]
-        : rawBounds
-
-      const bounds: [[number, number], [number, number]] = [
-        [boundsArray[0], boundsArray[1]],
-        [boundsArray[2], boundsArray[3]],
-      ]
-
-      map.value = new maplibre.Map({
-        hash: false,
-        container: `map-${props.id}`,
-        bounds,
-        fitBoundsOptions: {
-          padding: getPadding(container),
-          animate: false,
-          maxZoom: 17,
-        },
-        style: mapStyleUrl,
-        cooperativeGestures: true,
-        attributionControl: false,
-      })
-      map.value.addControl(new maplibre.FullscreenControl())
-
-      map.value.on('load', handleMapOnLoad)
-    }
+    map.value.on('load', handleMapOnLoad)
   }
 }
 

--- a/src/composables/useLoCha.ts
+++ b/src/composables/useLoCha.ts
@@ -87,9 +87,6 @@ export function useLoCha(): LoChaInterface {
     return loChaStatus.updateAfter
   }
 
-  /**
-   * Resets the LoCha state by clearing the LoCha data and resetting the feature arrays.
-   */
   function _resetState(): void {
     loCha.value = undefined
     groups.value = []
@@ -100,6 +97,7 @@ export function useLoCha(): LoChaInterface {
     loCha,
     groups,
     setLoCha,
+    resetLoCha: _resetState,
     getStatus,
     getBeforeFeatures,
     getAfterFeatures,

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -52,6 +52,7 @@ export interface LoCha {
   groups: Ref<LoChaGroup[]>
   loCha: Ref<LoChaData | undefined>
   setLoCha: (loCha: LoChaData) => void
+  resetLoCha: () => void
   getStatus: (feature: IFeature) => Status
   getBeforeFeatures: (features: IFeature[]) => IFeature[]
   getAfterFeatures: (features: IFeature[]) => IFeature[]


### PR DESCRIPTION
## Release v0.6.0

### Features
* feat: display before objects in compact mode for n+n after features

### Fixes
* fix: handle null geometry and degenerate bounds in VMap initMap
* fix: add missing IFeature import in LoChaGroup
* fix: skip refitBounds on setData when features lack geometry
* fix: update map source data on features change instead of recreating
* fix: align header-end content to the right
* fix: show before panel tags plainly without diff styling
* fix: hide deletion rows in before panel diff_tags
* fix: scroll to top when group list data changes
* fix: reset LoCha state when data prop becomes undefined
* fix: apply diff_tags categorization for new and delete objects
* fix: use adaptive padding in VMap to fix small viewport sizing
* fix: clamp VMap initial bounds to original query bbox

### Reverts
* revert: restore VMap to working state before source.setData refactor

### Styles
* style: add 3-column grid layout to locha-header to align with group-content
* style: rename Before/After labels to From/To in demo

**Full Changelog**: https://github.com/teritorio/openstreetmap-logical-history-component/commits/v0.6.0