### PR TITLE
chore: release v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ A scoped slot rendered once per group in the center of the group header (between
 | ------- | -------- | ---------------- |
 | `index` | `number` | The group index. |
 
+#### `#header-start-end`
+
+A scoped slot rendered once per group inside the left section of the group header, between the anchor button (🔗) and the group name. Useful for injecting a per-group action button close to the anchor.
+
+| Prop    | Type     | Description      |
+| ------- | -------- | ---------------- |
+| `index` | `number` | The group index. |
+
 #### `#header-end`
 
 A scoped slot rendered once per group at the right end of the group header. Useful for injecting per-group action buttons (e.g. accept/reject validation).
@@ -97,8 +105,11 @@ Example usage:
   <template #object-detail="{ feature, index }">
     <!-- Custom per-feature rendering -->
   </template>
-  <template #header-end="{ index }">
+  <template #header-start-end="{ index }">
     <button @click="acceptGroup(index)">Accept</button>
+  </template>
+  <template #header-end="{ index }">
+    <!-- Optional: action at the far right of the group header -->
   </template>
   <template #content-start="{ index }">
     <!-- Custom first-column content (e.g. changesets) -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teritorio/openstreetmap-logical-history-component",
   "type": "module",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "packageManager": "yarn@4.9.2",
   "description": "An OpenStreetMap logical history (LoCha) UI component.",
   "author": "Teritorio",

--- a/src/components/LoCha/LoCha.vue
+++ b/src/components/LoCha/LoCha.vue
@@ -19,6 +19,7 @@ const props = withDefaults(defineProps<{
 
 defineSlots<{
   'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-start-end'?: (props: GroupSlotProps) => void
   'header-center'?: (props: GroupSlotProps) => void
   'header-end'?: (props: GroupSlotProps) => void
   'content-start'?: (props: GroupSlotProps) => void
@@ -58,6 +59,9 @@ watch(() => props.data, (newValue) => {
     <LoChaGroupList v-else :hash="hash">
       <template v-if="$slots['object-detail']" #object-detail="slotProps">
         <slot name="object-detail" v-bind="slotProps" />
+      </template>
+      <template v-if="$slots['header-start-end']" #header-start-end="slotProps">
+        <slot name="header-start-end" v-bind="slotProps" />
       </template>
       <template v-if="$slots['header-center']" #header-center="slotProps">
         <slot name="header-center" v-bind="slotProps" />

--- a/src/components/LoCha/LoChaGroup.vue
+++ b/src/components/LoCha/LoChaGroup.vue
@@ -18,6 +18,7 @@ defineEmits<{
 
 defineSlots<{
   'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-start-end'?: (props: GroupSlotProps) => void
   'header-center'?: (props: GroupSlotProps) => void
   'header-end'?: (props: GroupSlotProps) => void
   'content-start'?: (props: GroupSlotProps) => void
@@ -82,6 +83,7 @@ const groupNameTitle = computed(() => {
     <div class="group-header">
       <div class="header-start">
         <a class="anchor-button" :href="`#${id}`" @click.prevent="$emit('navigate', `#${id}`)">🔗</a>
+        <slot name="header-start-end" :index="index" />
         <h3 class="group-name" :title="groupNameTitle">
           <span v-if="groupNameParts.before" class="name-before">{{ groupNameParts.before }}</span>
           <span v-if="groupNameParts.before" class="name-separator"> → </span>

--- a/src/components/LoCha/LoChaGroupList.vue
+++ b/src/components/LoCha/LoChaGroupList.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
 
 defineSlots<{
   'object-detail'?: (props: ObjectDetailSlotProps) => void
+  'header-start-end'?: (props: GroupSlotProps) => void
   'header-center'?: (props: GroupSlotProps) => void
   'header-end'?: (props: GroupSlotProps) => void
   'content-start'?: (props: GroupSlotProps) => void
@@ -100,6 +101,9 @@ onUnmounted(() => {
         <LoChaGroup :id="groupId(index)" :features="group" :index="index" :josm-target="josmTargetName()" @navigate="navigateToHash">
           <template v-if="$slots['object-detail']" #object-detail="slotProps">
             <slot name="object-detail" v-bind="slotProps" />
+          </template>
+          <template v-if="$slots['header-start-end']" #header-start-end="slotProps">
+            <slot name="header-start-end" v-bind="slotProps" />
           </template>
           <template v-if="$slots['header-center']" #header-center="slotProps">
             <slot name="header-center" v-bind="slotProps" />


### PR DESCRIPTION
Release v0.6.2 — adds `header-start-end` slot to LoChaGroup.

### Changes since v0.6.0

* feat: add header-start-end slot to LoChaGroup between anchor and group name
* fix: forward header-start-end slot through LoCha and LoChaGroupList